### PR TITLE
Parameters in Camel Casing

### DIFF
--- a/Sitecore 8.2.1/xm/README.md
+++ b/Sitecore 8.2.1/xm/README.md
@@ -22,9 +22,9 @@ The **deploymentId** and **licenseXml** parameters are filled in by the PowerShe
 
 | Parameter               | Description
 --------------------------|------------------------------------------------
-| sqlserverLogin         | The name of the administrator account for the newly created Azure SQL server.
-| sqlserverPassword      | The password for the administrator account for Azure SQL server.
-| sitecoreAdminPassword | The new password for the Sitecore **admin** account.
-| cm.msdeploy.packageurl  | The blob storage url to a Sitecore XM Content Management Web Deploy package.
-| cd.msdeploy.packageurl  | The blob storage url to a Sitecore XM Content Delivery Web Deploy package.
+| sqlserverLogin          | The name of the administrator account for the newly created Azure SQL server.
+| sqlserverPassword       | The password for the administrator account for Azure SQL server.
+| sitecoreAdminPassword   | The new password for the Sitecore **admin** account.
+| cmMsdeployPackageurl    | The blob storage url to a Sitecore XM Content Management Web Deploy package.
+| cdMsdeployPackageurl    | The blob storage url to a Sitecore XM Content Delivery Web Deploy package.
 

--- a/Sitecore 8.2.1/xm/README.md
+++ b/Sitecore 8.2.1/xm/README.md
@@ -22,9 +22,9 @@ The **deploymentId** and **licenseXml** parameters are filled in by the PowerShe
 
 | Parameter               | Description
 --------------------------|------------------------------------------------
-| sqlserver.login         | The name of the administrator account for the newly created Azure SQL server.
-| sqlserver.password      | The password for the administrator account for Azure SQL server.
-| sitecore.admin.password | The new password for the Sitecore **admin** account.
+| sqlserverLogin         | The name of the administrator account for the newly created Azure SQL server.
+| sqlserverPassword      | The password for the administrator account for Azure SQL server.
+| sitecoreAdminPassword | The new password for the Sitecore **admin** account.
 | cm.msdeploy.packageurl  | The blob storage url to a Sitecore XM Content Management Web Deploy package.
 | cd.msdeploy.packageurl  | The blob storage url to a Sitecore XM Content Delivery Web Deploy package.
 

--- a/Sitecore 8.2.1/xm/azuredeploy.json
+++ b/Sitecore 8.2.1/xm/azuredeploy.json
@@ -7,17 +7,17 @@
     "searchApiVersion": "2015-02-28",
     "redisApiVersion": "2016-04-01",
     "appInsightsApiVersion": "2014-08-01",
-    "cmHostingPlanNameTidy": "[toLower(trim(parameters('cm.hostingplan.name')))]",
-    "cdHostingPlanNameTidy": "[toLower(trim(parameters('cd.hostingplan.name')))]",
-    "cmWebAppNameTidy": "[toLower(trim(parameters('cm.webapp.name')))]",
-    "cdWebAppNameTidy": "[toLower(trim(parameters('cd.webapp.name')))]",
+    "cmHostingPlanNameTidy": "[toLower(trim(parameters('cmHostingplanName')))]",
+    "cdHostingPlanNameTidy": "[toLower(trim(parameters('cdHostingplanName')))]",
+    "cmWebAppNameTidy": "[toLower(trim(parameters('cmWebappName')))]",
+    "cdWebAppNameTidy": "[toLower(trim(parameters('cdWebappName')))]",
     "dbServerNameTidy": "[toLower(trim(parameters('sqlserverName')))]",
     "coreDbNameTidy": "[toLower(trim(parameters('coreSqldatabaseName')))]",
     "webDbNameTidy": "[toLower(trim(parameters('webSqldatabaseName')))]",
     "webDbServerNameTidy": "[toLower(trim(parameters('webSqlserverName')))]",
     "masterDbNameTidy": "[toLower(trim(parameters('masterSqldatabaseName')))]",
     "searchServiceNameTidy": "[toLower(trim(parameters('searchserviceName')))]",
-    "redisCacheNameTidy": "[toLower(trim(parameters('rediscache.name')))]",
+    "redisCacheNameTidy": "[toLower(trim(parameters('rediscacheName')))]",
     "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsightsName')))]",
     "licenseXml": "[parameters('licenseXml')]"
   },
@@ -30,26 +30,26 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "cm.hostingplan.name": {
+    "cmHostingplanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cm-hp')]"
     },
-    "cd.hostingplan.name": {
+    "cdHostingplanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cd-hp')]"
     },
-    "cm.webapp.name": {
+    "cmWebappName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cm')]"
     },
-    "cd.webapp.name": {
+    "cdWebappName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cd')]"
     },
-    "cm.msdeploy.packageurl": {
+    "cmMsdeployPackageurl": {
       "type": "securestring"
     },
-    "cd.msdeploy.packageurl": {
+    "cdMsdeployPackageurl": {
       "type": "securestring"
     },
     "sqlserverName": {
@@ -90,52 +90,52 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-web-db')]"
     },
-    "cm.core.sqldatabase.username": {
+    "cmCoreSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cm-core-', deployment().name, '-user')]"
     },
-    "cm.core.sqldatabase.password": {
+    "cmCoreSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cm-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cm.master.sqldatabase.username": {
+    "cmMasterSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cm-master-', deployment().name, '-user')]"
     },
-    "cm.master.sqldatabase.password": {
+    "cmMasterSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cm-master')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cm.web.sqldatabase.username": {
+    "cmWebSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cm-web-', deployment().name, '-user')]"
     },
-    "cm.web.sqldatabase.password": {
+    "cmWebSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cm-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cd.core.sqldatabase.username": {
+    "cdCoreSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cd-core-', deployment().name, '-user')]"
     },
-    "cd.core.sqldatabase.password": {
+    "cdCoreSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cd-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cd.web.sqldatabase.username": {
+    "cdWebSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cd-web-', deployment().name, '-user')]"
     },
-    "cd.web.sqldatabase.password": {
+    "cdWebSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cd-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
@@ -144,7 +144,7 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-as')]"
     },
-    "rediscache.name": {
+    "rediscacheName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-redis')]"
     },
@@ -157,19 +157,19 @@
       "defaultValue": "East US",
       "allowedValues": [ "East US", "South Central US", "North Europe", "West Europe" ]
     },
-    "cm.hostingplan.skuname": {
+    "cmHostingplanSkuname": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "cm.hostingplan.skucapacity": {
+    "cmHostingplanSkucapacity": {
       "type": "int",
       "defaultValue": 1
     },
-    "cd.hostingplan.skuname": {
+    "cdHostingplanSkuname": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "cd.hostingplan.skucapacity": {
+    "cdHostingplanSkucapacity": {
       "type": "int",
       "defaultValue": 1
     },
@@ -205,15 +205,15 @@
       "type": "int",
       "defaultValue": 1
     },
-    "rediscache.skuname": {
+    "rediscacheSkuname": {
       "type": "string",
       "defaultValue": "Basic"
     },
-    "rediscache.skufamily": {
+    "rediscacheSkufamily": {
       "type": "string",
       "defaultValue": "C"
     },
-    "rediscache.skucapacity": {
+    "rediscacheSkucapacity": {
       "type": "string",
       "defaultValue": "0"
     },
@@ -226,11 +226,11 @@
     "licenseXml": {
       "type": "securestring"
     },
-    "security.clientIp": {
+    "securityClientIp": {
       "type": "string",
       "defaultValue": "0.0.0.0"
     },
-    "security.clientIpMask": {
+    "securityClientIpMask": {
       "type": "string",
       "defaultValue": "0.0.0.0"
     },
@@ -246,8 +246,8 @@
       "name": "[variables('cmHostingPlanNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "sku": {
-        "name": "[parameters('cm.hostingplan.skuname')]",
-        "capacity": "[parameters('cm.hostingplan.skucapacity')]"
+        "name": "[parameters('cmHostingplanSkuname')]",
+        "capacity": "[parameters('cmHostingplanSkucapacity')]"
       },
       "properties": {
         "name": "[variables('cmHostingPlanNameTidy')]"
@@ -262,8 +262,8 @@
       "name": "[variables('cdHostingPlanNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "sku": {
-        "name": "[parameters('cd.hostingplan.skuname')]",
-        "capacity": "[parameters('cd.hostingplan.skucapacity')]"
+        "name": "[parameters('cdHostingplanSkuname')]",
+        "capacity": "[parameters('cdHostingplanSkucapacity')]"
       },
       "properties": {
         "name": "[variables('cdHostingPlanNameTidy')]"
@@ -302,31 +302,31 @@
           "apiVersion": "[variables('webApiVersion')]",
           "dependsOn": [ "[concat('Microsoft.Web/sites/', variables('cmWebAppNameTidy'))]", "[resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy'))]", "[resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('coreDbNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('masterDbNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'), '/databases/', variables('webDbNameTidy'))]" ],
           "properties": {
-            "packageUri": "[parameters('cm.msdeploy.packageurl')]",
+            "packageUri": "[parameters('cmMsdeployPackageurl')]",
             "dbType": "SQL",
             "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cmWebAppNameTidy')]",
               "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
-              "Core DB User Name": "[parameters('cm.core.sqldatabase.username')]",
-              "Core DB Password": "[parameters('cm.core.sqldatabase.password')]",
+              "Core DB User Name": "[parameters('cmCoreSqldatabaseUsername')]",
+              "Core DB Password": "[parameters('cmCoreSqldatabasePassword')]",
               "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cm.core.sqldatabase.username'), ';Password=', parameters('cm.core.sqldatabase.password'), ';')]",
-              "Master DB User Name": "[parameters('cm.master.sqldatabase.username')]",
-              "Master DB Password": "[parameters('cm.master.sqldatabase.password')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cmCoreSqldatabaseUsername'), ';Password=', parameters('cmCoreSqldatabasePassword'), ';')]",
+              "Master DB User Name": "[parameters('cmMasterSqldatabaseUsername')]",
+              "Master DB Password": "[parameters('cmMasterSqldatabasePassword')]",
               "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('cm.master.sqldatabase.username'), ';Password=', parameters('cm.master.sqldatabase.password'), ';')]",
-              "Web DB User Name": "[parameters('cm.web.sqldatabase.username')]",
-              "Web DB Password": "[parameters('cm.web.sqldatabase.password')]",
+              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('cmMasterSqldatabaseUsername'), ';Password=', parameters('cmMasterSqldatabasePassword'), ';')]",
+              "Web DB User Name": "[parameters('cmWebSqldatabaseUsername')]",
+              "Web DB Password": "[parameters('cmWebSqldatabasePassword')]",
               "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
-              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cm.web.sqldatabase.username'), ';Password=', parameters('cm.web.sqldatabase.password'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cmWebSqldatabaseUsername'), ';Password=', parameters('cmWebSqldatabasePassword'), ';')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Application Insights Instrumentation Key": "[reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))).InstrumentationKey]",
               "Application Insights Role": "CM",
               "KeepAlive Url": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('cmWebAppNameTidy'))).hostNames[0], '/sitecore/service/keepalive.aspx')]",
               "License Xml": "[variables('licenseXml')]",
-              "IP Security Client IP": "[parameters('security.clientIp')]",
-              "IP Security Client IP Mask": "[parameters('security.clientIpMask')]"
+              "IP Security Client IP": "[parameters('securityClientIp')]",
+              "IP Security Client IP Mask": "[parameters('securityClientIpMask')]"
             }
           }
         }
@@ -370,20 +370,20 @@
             "[concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'), '/databases/', variables('webDbNameTidy'))]"
           ],
           "properties": {
-            "packageUri": "[parameters('cd.msdeploy.packageurl')]",
+            "packageUri": "[parameters('cdMsdeployPackageurl')]",
             "dbType": "SQL",
             "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cdWebAppNameTidy')]",
               "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
-              "Core DB User Name": "[parameters('cd.core.sqldatabase.username')]",
-              "Core DB Password": "[parameters('cd.core.sqldatabase.password')]",
+              "Core DB User Name": "[parameters('cdCoreSqldatabaseUsername')]",
+              "Core DB Password": "[parameters('cdCoreSqldatabasePassword')]",
               "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cd.core.sqldatabase.username'), ';Password=', parameters('cd.core.sqldatabase.password'), ';')]",
-              "Web DB User Name": "[parameters('cd.web.sqldatabase.username')]",
-              "Web DB Password": "[parameters('cd.web.sqldatabase.password')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cdCoreSqldatabaseUsername'), ';Password=', parameters('cdCoreSqldatabasePassword'), ';')]",
+              "Web DB User Name": "[parameters('cdWebSqldatabaseUsername')]",
+              "Web DB Password": "[parameters('cdWebSqldatabasePassword')]",
               "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
-              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cd.web.sqldatabase.username'), ';Password=', parameters('cd.web.sqldatabase.password'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cdWebSqldatabaseUsername'), ';Password=', parameters('cdWebSqldatabasePassword'), ';')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Application Insights Instrumentation Key": "[reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))).InstrumentationKey]",
               "Application Insights Role": "CD",
@@ -518,9 +518,9 @@
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
-          "name": "[parameters('rediscache.skuname')]",
-          "family": "[parameters('rediscache.skufamily')]",
-          "capacity": "[parameters('rediscache.skucapacity')]"
+          "name": "[parameters('rediscacheSkuname')]",
+          "family": "[parameters('rediscacheSkufamily')]",
+          "capacity": "[parameters('rediscacheSkucapacity')]"
         },
         "enableNonSslPort": false
       },

--- a/Sitecore 8.2.1/xm/azuredeploy.json
+++ b/Sitecore 8.2.1/xm/azuredeploy.json
@@ -197,7 +197,7 @@
       "type": "string",
       "defaultValue": "S1"
     },
-    "searchservice.cdlicacount": {
+    "searchserviceCdlicacount": {
       "type": "int",
       "defaultValue": 1
     },
@@ -504,7 +504,7 @@
         "sku": {
           "name": "[toLower(parameters('searchserviceSkuname'))]"
         },
-        "cdlicaCount": "[parameters('searchservice.cdlicacount')]",
+        "cdlicaCount": "[parameters('searchserviceCdlicacount')]",
         "partitionCount": "[parameters('searchservicePartitioncount')]"
       },
       "tags": {

--- a/Sitecore 8.2.1/xm/azuredeploy.json
+++ b/Sitecore 8.2.1/xm/azuredeploy.json
@@ -11,14 +11,14 @@
     "cdHostingPlanNameTidy": "[toLower(trim(parameters('cd.hostingplan.name')))]",
     "cmWebAppNameTidy": "[toLower(trim(parameters('cm.webapp.name')))]",
     "cdWebAppNameTidy": "[toLower(trim(parameters('cd.webapp.name')))]",
-    "dbServerNameTidy": "[toLower(trim(parameters('sqlserver.name')))]",
-    "coreDbNameTidy": "[toLower(trim(parameters('core.sqldatabase.name')))]",
-    "webDbNameTidy": "[toLower(trim(parameters('web.sqldatabase.name')))]",
-    "webDbServerNameTidy": "[toLower(trim(parameters('web.sqlserver.name')))]",
-    "masterDbNameTidy": "[toLower(trim(parameters('master.sqldatabase.name')))]",
-    "searchServiceNameTidy": "[toLower(trim(parameters('searchservice.name')))]",
+    "dbServerNameTidy": "[toLower(trim(parameters('sqlserverName')))]",
+    "coreDbNameTidy": "[toLower(trim(parameters('coreSqldatabaseName')))]",
+    "webDbNameTidy": "[toLower(trim(parameters('webSqldatabaseName')))]",
+    "webDbServerNameTidy": "[toLower(trim(parameters('webSqlserverName')))]",
+    "masterDbNameTidy": "[toLower(trim(parameters('masterSqldatabaseName')))]",
+    "searchServiceNameTidy": "[toLower(trim(parameters('searchserviceName')))]",
     "redisCacheNameTidy": "[toLower(trim(parameters('rediscache.name')))]",
-    "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsights.name')))]",
+    "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsightsName')))]",
     "licenseXml": "[parameters('licenseXml')]"
   },
   "parameters": {
@@ -52,41 +52,41 @@
     "cd.msdeploy.packageurl": {
       "type": "securestring"
     },
-    "sqlserver.name": {
+    "sqlserverName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-sql')]"
     },
-    "sqlserver.login": {
+    "sqlserverLogin": {
       "type": "string",
       "minLength": 1
     },
-    "sqlserver.password": {
+    "sqlserverPassword": {
       "type": "securestring",
       "minLength": 8
     },
-    "web.sqlserver.name": {
+    "webSqlserverName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-web-sql')]"
     },
-    "web.sqlserver.login": {
+    "webSqlserverLogin": {
       "type": "string",
       "minLength": 1,
-      "defaultValue": "[parameters('sqlserver.login')]"
+      "defaultValue": "[parameters('sqlserverLogin')]"
     },
-    "web.sqlserver.password": {
+    "webSqlserverPassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[parameters('sqlserver.password')]"
+      "defaultValue": "[parameters('sqlserverPassword')]"
     },
-    "core.sqldatabase.name": {
+    "coreSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-core-db')]"
     },
-    "master.sqldatabase.name": {
+    "masterSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-master-db')]"
     },
-    "web.sqldatabase.name": {
+    "webSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-web-db')]"
     },
@@ -98,7 +98,7 @@
     "cm.core.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cm-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cm-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "cm.master.sqldatabase.username": {
       "type": "string",
@@ -108,7 +108,7 @@
     "cm.master.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cm-master')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cm-master')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "cm.web.sqldatabase.username": {
       "type": "string",
@@ -118,7 +118,7 @@
     "cm.web.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cm-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cm-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "cd.core.sqldatabase.username": {
       "type": "string",
@@ -128,7 +128,7 @@
     "cd.core.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cd-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cd-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "cd.web.sqldatabase.username": {
       "type": "string",
@@ -138,9 +138,9 @@
     "cd.web.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cd-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cd-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "searchservice.name": {
+    "searchserviceName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-as')]"
     },
@@ -148,11 +148,11 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-redis')]"
     },
-    "applicationinsights.name": {
+    "applicationinsightsName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-ai')]"
     },
-    "applicationinsights.location": {
+    "applicationinsightsLocation": {
       "type": "string",
       "defaultValue": "East US",
       "allowedValues": [ "East US", "South Central US", "North Europe", "West Europe" ]
@@ -173,27 +173,27 @@
       "type": "int",
       "defaultValue": 1
     },
-    "searchservice.skuname": {
+    "searchserviceSkuname": {
       "type": "string",
       "defaultValue": "Standard"
     },
-    "sqlserver.version": {
+    "sqlserverVersion": {
       "type": "string",
       "defaultValue": "12.0"
     },
-    "sqldatabase.collation": {
+    "sqldatabaseCollation": {
       "type": "string",
       "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
     },
-    "sqldatabase.edition": {
+    "sqldatabaseEdition": {
       "type": "string",
       "defaultValue": "Standard"
     },
-    "sqldatabase.maxsize": {
+    "sqldatabaseMaxsize": {
       "type": "string",
       "defaultValue": "10737418240"
     },
-    "sqldatabase.serviceobjectivelevel": {
+    "sqldatabaseServiceobjectivelevel": {
       "type": "string",
       "defaultValue": "S1"
     },
@@ -201,7 +201,7 @@
       "type": "int",
       "defaultValue": 1
     },
-    "searchservice.partitioncount": {
+    "searchservicePartitioncount": {
       "type": "int",
       "defaultValue": 1
     },
@@ -234,7 +234,7 @@
       "type": "string",
       "defaultValue": "0.0.0.0"
     },
-    "sitecore.admin.password": {
+    "sitecoreAdminPassword": {
       "type": "securestring",
       "minLength": 8,
       "maxLength": 128
@@ -304,21 +304,21 @@
           "properties": {
             "packageUri": "[parameters('cm.msdeploy.packageurl')]",
             "dbType": "SQL",
-            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cmWebAppNameTidy')]",
-              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
+              "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
               "Core DB User Name": "[parameters('cm.core.sqldatabase.username')]",
               "Core DB Password": "[parameters('cm.core.sqldatabase.password')]",
-              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cm.core.sqldatabase.username'), ';Password=', parameters('cm.core.sqldatabase.password'), ';')]",
               "Master DB User Name": "[parameters('cm.master.sqldatabase.username')]",
               "Master DB Password": "[parameters('cm.master.sqldatabase.password')]",
-              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('cm.master.sqldatabase.username'), ';Password=', parameters('cm.master.sqldatabase.password'), ';')]",
               "Web DB User Name": "[parameters('cm.web.sqldatabase.username')]",
               "Web DB Password": "[parameters('cm.web.sqldatabase.password')]",
-              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
               "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cm.web.sqldatabase.username'), ';Password=', parameters('cm.web.sqldatabase.password'), ';')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Application Insights Instrumentation Key": "[reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))).InstrumentationKey]",
@@ -372,17 +372,17 @@
           "properties": {
             "packageUri": "[parameters('cd.msdeploy.packageurl')]",
             "dbType": "SQL",
-            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cdWebAppNameTidy')]",
-              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
+              "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
               "Core DB User Name": "[parameters('cd.core.sqldatabase.username')]",
               "Core DB Password": "[parameters('cd.core.sqldatabase.password')]",
-              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cd.core.sqldatabase.username'), ';Password=', parameters('cd.core.sqldatabase.password'), ';')]",
               "Web DB User Name": "[parameters('cd.web.sqldatabase.username')]",
               "Web DB Password": "[parameters('cd.web.sqldatabase.password')]",
-              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
               "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cd.web.sqldatabase.username'), ';Password=', parameters('cd.web.sqldatabase.password'), ';')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Application Insights Instrumentation Key": "[reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))).InstrumentationKey]",
@@ -399,9 +399,9 @@
       "type": "Microsoft.Sql/servers",
       "apiVersion": "[variables('dbApiVersion')]",
       "properties": {
-        "administratorLogin": "[parameters('sqlserver.login')]",
-        "administratorLoginPassword": "[parameters('sqlserver.password')]",
-        "version": "[parameters('sqlserver.version')]"
+        "administratorLogin": "[parameters('sqlserverLogin')]",
+        "administratorLoginPassword": "[parameters('sqlserverPassword')]",
+        "version": "[parameters('sqlserverVersion')]"
       },
       "name": "[variables('dbServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -423,10 +423,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('coreDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -439,10 +439,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('masterDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -457,9 +457,9 @@
       "type": "Microsoft.Sql/servers",
       "apiVersion": "[variables('dbApiVersion')]",
       "properties": {
-        "administratorLogin": "[parameters('web.sqlserver.login')]",
-        "administratorLoginPassword": "[parameters('web.sqlserver.password')]",
-        "version": "[parameters('sqlserver.version')]"
+        "administratorLogin": "[parameters('webSqlserverLogin')]",
+        "administratorLoginPassword": "[parameters('webSqlserverPassword')]",
+        "version": "[parameters('sqlserverVersion')]"
       },
       "name": "[variables('webDbServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -481,10 +481,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('webDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -502,10 +502,10 @@
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
-          "name": "[toLower(parameters('searchservice.skuname'))]"
+          "name": "[toLower(parameters('searchserviceSkuname'))]"
         },
         "cdlicaCount": "[parameters('searchservice.cdlicacount')]",
-        "partitionCount": "[parameters('searchservice.partitioncount')]"
+        "partitionCount": "[parameters('searchservicePartitioncount')]"
       },
       "tags": {
         "provider": "[parameters('sitecoreTags').provider]"
@@ -533,7 +533,7 @@
       "type": "Microsoft.Insights/Components",
       "name": "[variables('appInsightsNameTidy')]",
       "apiVersion": "[variables('appInsightsApiVersion')]",
-      "location": "[parameters('applicationinsights.location')]",
+      "location": "[parameters('applicationinsightsLocation')]",
       "properties": {
         "ApplicationId": "[variables('appInsightsNameTidy')]",
         "Application_Type": "web"

--- a/Sitecore 8.2.1/xm/azuredeploy.parameters.json
+++ b/Sitecore 8.2.1/xm/azuredeploy.parameters.json
@@ -2,13 +2,13 @@
   "deploymentId": {
     "value": ""
   },
-  "sitecore.admin.password": {
+  "sitecoreAdminPassword": {
     "value": ""
   },
-  "sqlserver.login": {
+  "sqlserverLogin": {
     "value": ""
   },
-  "sqlserver.password": {
+  "sqlserverPassword": {
     "value": ""
   },
   "cm.msdeploy.packageurl": {

--- a/Sitecore 8.2.1/xm/azuredeploy.parameters.json
+++ b/Sitecore 8.2.1/xm/azuredeploy.parameters.json
@@ -11,10 +11,10 @@
   "sqlserverPassword": {
     "value": ""
   },
-  "cm.msdeploy.packageurl": {
+  "cmMsdeployPackageurl": {
     "value": ""
   },
-  "cd.msdeploy.packageurl": {
+  "cdMsdeployPackageurl": {
     "value": ""
   },
   "licenseXml": {

--- a/Sitecore 8.2.1/xp/README.md
+++ b/Sitecore 8.2.1/xp/README.md
@@ -29,7 +29,7 @@ The **deploymentId** and **licenseXml** parameters are filled in by the PowerShe
 | cdMsdeployPackageurl                      | The blob storage url to a Sitecore XP Content Delivery Web Deploy package.
 | prcMsdeployPackageurl                     | The blob storage url to a Sitecore XP Processing Web Deploy package.
 | repMsdeployPackageurl                     | The blob storage url to a Sitecore XP Reporting Web Deploy package.
-| rep.authentication.apikey                 | A unique value (e.g. a GUID) that will be used as authentication when communicating from Content Management to the Reporting Web App.
+| repAuthenticationApikey                   | A unique value (e.g. a GUID) that will be used as authentication when communicating from Content Management to the Reporting Web App.
 | analyticsMongodbConnectionstring          | A MongoDB connection string for the analytics database.
 | trackingLiveMongodbConnectionstring       | A MongoDB connection string for the tracking.live database.
 | trackingHistoryMongodbConnectionstring    | A MongoDB connection string for the tracking.history database.

--- a/Sitecore 8.2.1/xp/README.md
+++ b/Sitecore 8.2.1/xp/README.md
@@ -22,17 +22,17 @@ The **deploymentId** and **licenseXml** parameters are filled in by the PowerShe
 
 |Parameter                                  | Description
 --------------------------------------------|----------------------------------------------------
-| sqlserver.login                           | The name of the administrator account for Azure SQL server that will be created.
-| sqlserver.password                        | The password for the administrator account for Azure SQL server.
-| sitecore.admin.password                   | The new password for the Sitecore **admin** account.
+| sqlserverLogin                           | The name of the administrator account for Azure SQL server that will be created.
+| sqlserverPassword                        | The password for the administrator account for Azure SQL server.
+| sitecoreAdminPassword                   | The new password for the Sitecore **admin** account.
 | cm.msdeploy.packageurl                    | The blob storage url to a Sitecore XP Content Management Web Deploy package.
 | cd.msdeploy.packageurl                    | The blob storage url to a Sitecore XP Content Delivery Web Deploy package.
 | prc.msdeploy.packageurl                   | The blob storage url to a Sitecore XP Processing Web Deploy package.
 | rep.msdeploy.packageurl                   | The blob storage url to a Sitecore XP Reporting Web Deploy package.
 | rep.authentication.apikey                 | A unique value (e.g. a GUID) that will be used as authentication when communicating from Content Management to the Reporting Web App.
-| analytics.mongodb.connectionstring        | A MongoDB connection string for the analytics database.
-| tracking.live.mongodb.connectionstring    | A MongoDB connection string for the tracking.live database.
-| tracking.history.mongodb.connectionstring | A MongoDB connection string for the tracking.history database.
-| tracking.contact.mongodb.connectionstring | A MongoDB connection string for the tracking.contact database.
+| analyticsMongodbConnectionstring        | A MongoDB connection string for the analytics database.
+| trackingLiveMongodbConnectionstring    | A MongoDB connection string for the tracking.live database.
+| trackingHistoryMongodbConnectionstring | A MongoDB connection string for the tracking.history database.
+| trackingContactMongodbConnectionstring | A MongoDB connection string for the tracking.contact database.
 
 

--- a/Sitecore 8.2.1/xp/README.md
+++ b/Sitecore 8.2.1/xp/README.md
@@ -22,17 +22,17 @@ The **deploymentId** and **licenseXml** parameters are filled in by the PowerShe
 
 |Parameter                                  | Description
 --------------------------------------------|----------------------------------------------------
-| sqlserverLogin                           | The name of the administrator account for Azure SQL server that will be created.
-| sqlserverPassword                        | The password for the administrator account for Azure SQL server.
-| sitecoreAdminPassword                   | The new password for the Sitecore **admin** account.
-| cm.msdeploy.packageurl                    | The blob storage url to a Sitecore XP Content Management Web Deploy package.
-| cd.msdeploy.packageurl                    | The blob storage url to a Sitecore XP Content Delivery Web Deploy package.
-| prc.msdeploy.packageurl                   | The blob storage url to a Sitecore XP Processing Web Deploy package.
-| rep.msdeploy.packageurl                   | The blob storage url to a Sitecore XP Reporting Web Deploy package.
+| sqlserverLogin                            | The name of the administrator account for Azure SQL server that will be created.
+| sqlserverPassword                         | The password for the administrator account for Azure SQL server.
+| sitecoreAdminPassword                     | The new password for the Sitecore **admin** account.
+| cmMsdeployPackageurl                      | The blob storage url to a Sitecore XP Content Management Web Deploy package.
+| cdMsdeployPackageurl                      | The blob storage url to a Sitecore XP Content Delivery Web Deploy package.
+| prcMsdeployPackageurl                     | The blob storage url to a Sitecore XP Processing Web Deploy package.
+| repMsdeployPackageurl                     | The blob storage url to a Sitecore XP Reporting Web Deploy package.
 | rep.authentication.apikey                 | A unique value (e.g. a GUID) that will be used as authentication when communicating from Content Management to the Reporting Web App.
-| analyticsMongodbConnectionstring        | A MongoDB connection string for the analytics database.
-| trackingLiveMongodbConnectionstring    | A MongoDB connection string for the tracking.live database.
-| trackingHistoryMongodbConnectionstring | A MongoDB connection string for the tracking.history database.
-| trackingContactMongodbConnectionstring | A MongoDB connection string for the tracking.contact database.
+| analyticsMongodbConnectionstring          | A MongoDB connection string for the analytics database.
+| trackingLiveMongodbConnectionstring       | A MongoDB connection string for the tracking.live database.
+| trackingHistoryMongodbConnectionstring    | A MongoDB connection string for the tracking.history database.
+| trackingContactMongodbConnectionstring    | A MongoDB connection string for the tracking.contact database.
 
 

--- a/Sitecore 8.2.1/xp/azuredeploy.json
+++ b/Sitecore 8.2.1/xp/azuredeploy.json
@@ -15,19 +15,19 @@
     "cdWebAppNameTidy": "[toLower(trim(parameters('cd.webapp.name')))]",
     "prcWebAppNameTidy": "[toLower(trim(parameters('prc.webapp.name')))]",
     "repWebAppNameTidy": "[toLower(trim(parameters('rep.webapp.name')))]",
-    "dbServerNameTidy": "[toLower(trim(parameters('sqlserver.name')))]",
-    "webDbServerNameTidy": "[toLower(trim(parameters('web.sqlserver.name')))]",
-    "coreDbNameTidy": "[toLower(trim(parameters('core.sqldatabase.name')))]",
-    "webDbNameTidy": "[toLower(trim(parameters('web.sqldatabase.name')))]",
-    "masterDbNameTidy": "[toLower(trim(parameters('master.sqldatabase.name')))]",
-    "repDbNameTidy": "[toLower(trim(parameters('reporting.sqldatabase.name')))]",
-    "analyticsMongoDbConnStrTidy": "[trim(parameters('analytics.mongodb.connectionstring'))]",
-    "trackingLiveMongoDbConnStrTidy": "[trim(parameters('tracking.live.mongodb.connectionstring'))]",
-    "trackingHistoryMongoDbConnStrTidy": "[trim(parameters('tracking.history.mongodb.connectionstring'))]",
-    "trackingContactMongoDbConnStrTidy": "[trim(parameters('tracking.contact.mongodb.connectionstring'))]",
-    "searchServiceNameTidy": "[toLower(trim(parameters('searchservice.name')))]",
+    "dbServerNameTidy": "[toLower(trim(parameters('sqlserverName')))]",
+    "webDbServerNameTidy": "[toLower(trim(parameters('webSqlserverName')))]",
+    "coreDbNameTidy": "[toLower(trim(parameters('coreSqldatabaseName')))]",
+    "webDbNameTidy": "[toLower(trim(parameters('webSqldatabaseName')))]",
+    "masterDbNameTidy": "[toLower(trim(parameters('masterSqldatabaseName')))]",
+    "repDbNameTidy": "[toLower(trim(parameters('reportingSqldatabaseName')))]",
+    "analyticsMongoDbConnStrTidy": "[trim(parameters('analyticsMongodbConnectionstring'))]",
+    "trackingLiveMongoDbConnStrTidy": "[trim(parameters('trackingLiveMongodbConnectionstring'))]",
+    "trackingHistoryMongoDbConnStrTidy": "[trim(parameters('trackingHistoryMongodbConnectionstring'))]",
+    "trackingContactMongoDbConnStrTidy": "[trim(parameters('trackingContactMongodbConnectionstring'))]",
+    "searchServiceNameTidy": "[toLower(trim(parameters('searchserviceName')))]",
     "redisCacheNameTidy": "[toLower(trim(parameters('rediscache.name')))]",
-    "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsights.name')))]",
+    "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsightsName')))]",
     "licenseXml": "[parameters('licenseXml')]"
   },
   "parameters": {
@@ -83,45 +83,45 @@
     "rep.msdeploy.packageurl": {
       "type": "securestring"
     },
-    "sqlserver.name": {
+    "sqlserverName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-sql')]"
     },
-    "sqlserver.login": {
+    "sqlserverLogin": {
       "type": "string",
       "minLength": 1
     },
-    "sqlserver.password": {
+    "sqlserverPassword": {
       "type": "securestring",
       "minLength": 8
     },
-    "web.sqlserver.name": {
+    "webSqlserverName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-web-sql')]"
     },
-    "web.sqlserver.login": {
+    "webSqlserverLogin": {
       "type": "string",
       "minLength": 1,
-      "defaultValue": "[parameters('sqlserver.login')]"
+      "defaultValue": "[parameters('sqlserverLogin')]"
     },
-    "web.sqlserver.password": {
+    "webSqlserverPassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[parameters('sqlserver.password')]"
+      "defaultValue": "[parameters('sqlserverPassword')]"
     },
-    "core.sqldatabase.name": {
+    "coreSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-core-db')]"
     },
-    "master.sqldatabase.name": {
+    "masterSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-master-db')]"
     },
-    "web.sqldatabase.name": {
+    "webSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-web-db')]"
     },
-    "reporting.sqldatabase.name": {
+    "reportingSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-reporting-db')]"
     },
@@ -133,7 +133,7 @@
     "cm.core.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cm-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cm-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "cm.master.sqldatabase.username": {
       "type": "string",
@@ -143,7 +143,7 @@
     "cm.master.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cm-master')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cm-master')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "cm.web.sqldatabase.username": {
       "type": "string",
@@ -153,7 +153,7 @@
     "cm.web.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cm-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cm-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "cd.core.sqldatabase.username": {
       "type": "string",
@@ -163,7 +163,7 @@
     "cd.core.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cd-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cd-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "cd.web.sqldatabase.username": {
       "type": "string",
@@ -173,7 +173,7 @@
     "cd.web.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('cd-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('cd-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "prc.core.sqldatabase.username": {
       "type": "string",
@@ -183,7 +183,7 @@
     "prc.core.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('prc-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('prc-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "prc.master.sqldatabase.username": {
       "type": "string",
@@ -193,7 +193,7 @@
     "prc.master.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('prc-master')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('prc-master')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "prc.web.sqldatabase.username": {
       "type": "string",
@@ -203,7 +203,7 @@
     "prc.web.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('prc-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('prc-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "prc.reporting.sqldatabase.username": {
       "type": "string",
@@ -213,7 +213,7 @@
     "prc.reporting.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('prc-reporting')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('prc-reporting')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "rep.core.sqldatabase.username": {
       "type": "string",
@@ -223,7 +223,7 @@
     "rep.core.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('rep-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('rep-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "rep.master.sqldatabase.username": {
       "type": "string",
@@ -233,7 +233,7 @@
     "rep.master.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('rep-master')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('rep-master')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "rep.web.sqldatabase.username": {
       "type": "string",
@@ -243,7 +243,7 @@
     "rep.web.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('rep-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('rep-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
     "rep.reporting.sqldatabase.username": {
       "type": "string",
@@ -253,21 +253,21 @@
     "rep.reporting.sqldatabase.password": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('rep-reporting')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('rep-reporting')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "analytics.mongodb.connectionstring": {
+    "analyticsMongodbConnectionstring": {
       "type": "securestring"
     },
-    "tracking.live.mongodb.connectionstring": {
+    "trackingLiveMongodbConnectionstring": {
       "type": "securestring"
     },
-    "tracking.history.mongodb.connectionstring": {
+    "trackingHistoryMongodbConnectionstring": {
       "type": "securestring"
     },
-    "tracking.contact.mongodb.connectionstring": {
+    "trackingContactMongodbConnectionstring": {
       "type": "securestring"
     },
-    "searchservice.name": {
+    "searchserviceName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-as')]"
     },
@@ -275,11 +275,11 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-redis')]"
     },
-    "applicationinsights.name": {
+    "applicationinsightsName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-ai')]"
     },
-    "applicationinsights.location": {
+    "applicationinsightsLocation": {
       "type": "string",
       "defaultValue": "East US",
       "allowedValues": [ "East US", "South Central US", "North Europe", "West Europe" ]
@@ -316,35 +316,35 @@
       "type": "int",
       "defaultValue": 1
     },
-    "searchservice.skuname": {
+    "searchserviceSkuname": {
       "type": "string",
       "defaultValue": "Standard"
     },
-    "sqlserver.version": {
+    "sqlserverVersion": {
       "type": "string",
       "defaultValue": "12.0"
     },
-    "sqldatabase.collation": {
+    "sqldatabaseCollation": {
       "type": "string",
       "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
     },
-    "sqldatabase.edition": {
+    "sqldatabaseEdition": {
       "type": "string",
       "defaultValue": "Standard"
     },
-    "sqldatabase.maxsize": {
+    "sqldatabaseMaxsize": {
       "type": "string",
       "defaultValue": "10737418240"
     },
-    "sqldatabase.serviceobjectivelevel": {
+    "sqldatabaseServiceobjectivelevel": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "searchservice.replicacount": {
+    "searchserviceReplicacount": {
       "type": "int",
       "defaultValue": 1
     },
-    "searchservice.partitioncount": {
+    "searchservicePartitioncount": {
       "type": "int",
       "defaultValue": 1
     },
@@ -377,7 +377,7 @@
       "type": "string",
       "defaultValue": "0.0.0.0"
     },
-    "sitecore.admin.password": {
+    "sitecoreAdminPassword": {
       "type": "securestring",
       "minLength": 8,
       "maxLength": 128
@@ -494,23 +494,23 @@
           "properties": {
             "packageUri": "[parameters('cm.msdeploy.packageurl')]",
             "dbType": "SQL",
-            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cmWebAppNameTidy')]",
-              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
+              "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
               "Core DB User Name": "[parameters('cm.core.sqldatabase.username')]",
               "Core DB Password": "[parameters('cm.core.sqldatabase.password')]",
-              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cm.core.sqldatabase.username'), ';Password=', parameters('cm.core.sqldatabase.password'), ';')]",
               "Master DB User Name": "[parameters('cm.master.sqldatabase.username')]",
               "Master DB Password": "[parameters('cm.master.sqldatabase.password')]",
-              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('cm.master.sqldatabase.username'), ';Password=', parameters('cm.master.sqldatabase.password'), ';')]",
               "Web DB User Name": "[parameters('cm.web.sqldatabase.username')]",
               "Web DB Password": "[parameters('cm.web.sqldatabase.password')]",
-              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
               "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cm.web.sqldatabase.username'), ';Password=', parameters('cm.web.sqldatabase.password'), ';')]",
-              "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Analytics Connection String": "[variables('analyticsMongoDbConnStrTidy')]",
               "Tracking Live Connection String": "[variables('trackingLiveMongoDbConnStrTidy')]",
@@ -568,17 +568,17 @@
           "properties": {
             "packageUri": "[parameters('cd.msdeploy.packageurl')]",
             "dbType": "SQL",
-            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cdWebAppNameTidy')]",
-              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
+              "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
               "Core DB User Name": "[parameters('cd.core.sqldatabase.username')]",
               "Core DB Password": "[parameters('cd.core.sqldatabase.password')]",
-              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cd.core.sqldatabase.username'), ';Password=', parameters('cd.core.sqldatabase.password'), ';')]",
               "Web DB User Name": "[parameters('cd.web.sqldatabase.username')]",
               "Web DB Password": "[parameters('cd.web.sqldatabase.password')]",
-              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
               "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cd.web.sqldatabase.username'), ';Password=', parameters('cd.web.sqldatabase.password'), ';')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Analytics Connection String": "[variables('analyticsMongoDbConnStrTidy')]",
@@ -635,25 +635,25 @@
           "properties": {
             "packageUri": "[parameters('prc.msdeploy.packageurl')]",
             "dbType": "SQL",
-            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('prcWebAppNameTidy')]",
-              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
+              "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
               "Core DB User Name": "[parameters('prc.core.sqldatabase.username')]",
               "Core DB Password": "[parameters('prc.core.sqldatabase.password')]",
-              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('prc.core.sqldatabase.username'), ';Password=', parameters('prc.core.sqldatabase.password'), ';')]",
               "Master DB User Name": "[parameters('prc.master.sqldatabase.username')]",
               "Master DB Password": "[parameters('prc.master.sqldatabase.password')]",
-              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('prc.master.sqldatabase.username'), ';Password=', parameters('prc.master.sqldatabase.password'), ';')]",
               "Web DB User Name": "[parameters('prc.web.sqldatabase.username')]",
               "Web DB Password": "[parameters('prc.web.sqldatabase.password')]",
-              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
               "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('prc.web.sqldatabase.username'), ';Password=', parameters('prc.web.sqldatabase.password'), ';')]",
               "Reporting DB User Name": "[parameters('prc.reporting.sqldatabase.username')]",
               "Reporting DB Password": "[parameters('prc.reporting.sqldatabase.password')]",
-              "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('prc.reporting.sqldatabase.username'), ';Password=', parameters('prc.reporting.sqldatabase.password'), ';')]",
               "Analytics Connection String": "[variables('analyticsMongoDbConnStrTidy')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
@@ -712,25 +712,25 @@
           "properties": {
             "packageUri": "[parameters('rep.msdeploy.packageurl')]",
             "dbType": "SQL",
-            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('repWebAppNameTidy')]",
-              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
+              "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
               "Core DB User Name": "[parameters('rep.core.sqldatabase.username')]",
               "Core DB Password": "[parameters('rep.core.sqldatabase.password')]",
-              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('rep.core.sqldatabase.username'), ';Password=', parameters('rep.core.sqldatabase.password'), ';')]",
               "Master DB User Name": "[parameters('rep.master.sqldatabase.username')]",
               "Master DB Password": "[parameters('rep.master.sqldatabase.password')]",
-              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('rep.master.sqldatabase.username'), ';Password=', parameters('rep.master.sqldatabase.password'), ';')]",
               "Web DB User Name": "[parameters('rep.web.sqldatabase.username')]",
               "Web DB Password": "[parameters('rep.web.sqldatabase.password')]",
-              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
               "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('rep.web.sqldatabase.username'), ';Password=', parameters('rep.web.sqldatabase.password'), ';')]",
               "Reporting DB User Name": "[parameters('rep.reporting.sqldatabase.username')]",
               "Reporting DB Password": "[parameters('rep.reporting.sqldatabase.password')]",
-              "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
+              "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('rep.reporting.sqldatabase.username'), ';Password=', parameters('rep.reporting.sqldatabase.password'), ';')]",
               "Reporting Service Api Key": "[parameters('rep.authentication.apikey')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
@@ -750,9 +750,9 @@
       "type": "Microsoft.Sql/servers",
       "apiVersion": "[variables('dbApiVersion')]",
       "properties": {
-        "administratorLogin": "[parameters('sqlserver.login')]",
-        "administratorLoginPassword": "[parameters('sqlserver.password')]",
-        "version": "[parameters('sqlserver.version')]"
+        "administratorLogin": "[parameters('sqlserverLogin')]",
+        "administratorLoginPassword": "[parameters('sqlserverPassword')]",
+        "version": "[parameters('sqlserverVersion')]"
       },
       "name": "[variables('dbServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -774,10 +774,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('coreDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -790,10 +790,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('masterDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -806,10 +806,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('repDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -824,9 +824,9 @@
       "type": "Microsoft.Sql/servers",
       "apiVersion": "[variables('dbApiVersion')]",
       "properties": {
-        "administratorLogin": "[parameters('web.sqlserver.login')]",
-        "administratorLoginPassword": "[parameters('web.sqlserver.password')]",
-        "version": "[parameters('sqlserver.version')]"
+        "administratorLogin": "[parameters('webSqlserverLogin')]",
+        "administratorLoginPassword": "[parameters('webSqlserverPassword')]",
+        "version": "[parameters('sqlserverVersion')]"
       },
       "name": "[variables('webDbServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -848,10 +848,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('webDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -869,10 +869,10 @@
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
-          "name": "[toLower(parameters('searchservice.skuname'))]"
+          "name": "[toLower(parameters('searchserviceSkuname'))]"
         },
-        "replicaCount": "[parameters('searchservice.replicacount')]",
-        "partitionCount": "[parameters('searchservice.partitioncount')]"
+        "replicaCount": "[parameters('searchserviceReplicacount')]",
+        "partitionCount": "[parameters('searchservicePartitioncount')]"
       },
       "tags": {
         "provider": "[parameters('sitecoreTags').provider]"
@@ -900,7 +900,7 @@
       "type": "Microsoft.Insights/Components",
       "name": "[variables('appInsightsNameTidy')]",
       "apiVersion": "[variables('appInsightsApiVersion')]",
-      "location": "[parameters('applicationinsights.location')]",
+      "location": "[parameters('applicationinsightsLocation')]",
       "properties": {
         "ApplicationId": "[variables('appInsightsNameTidy')]",
         "Application_Type": "web"

--- a/Sitecore 8.2.1/xp/azuredeploy.json
+++ b/Sitecore 8.2.1/xp/azuredeploy.json
@@ -7,14 +7,14 @@
     "searchApiVersion": "2015-02-28",
     "redisApiVersion": "2016-04-01",
     "appInsightsApiVersion": "2014-08-01",
-    "cmHostingPlanNameTidy": "[toLower(trim(parameters('cm.hostingplan.name')))]",
-    "cdHostingPlanNameTidy": "[toLower(trim(parameters('cd.hostingplan.name')))]",
-    "prcHostingPlanNameTidy": "[toLower(trim(parameters('prc.hostingplan.name')))]",
-    "repHostingPlanNameTidy": "[toLower(trim(parameters('rep.hostingplan.name')))]",
-    "cmWebAppNameTidy": "[toLower(trim(parameters('cm.webapp.name')))]",
-    "cdWebAppNameTidy": "[toLower(trim(parameters('cd.webapp.name')))]",
+    "cmHostingPlanNameTidy": "[toLower(trim(parameters('cmHostingplanName')))]",
+    "cdHostingPlanNameTidy": "[toLower(trim(parameters('cdHostingplanName')))]",
+    "prcHostingPlanNameTidy": "[toLower(trim(parameters('prcHostingplanName')))]",
+    "repHostingPlanNameTidy": "[toLower(trim(parameters('repHostingplanName')))]",
+    "cmWebAppNameTidy": "[toLower(trim(parameters('cmWebappName')))]",
+    "cdWebAppNameTidy": "[toLower(trim(parameters('cdWebappName')))]",
     "prcWebAppNameTidy": "[toLower(trim(parameters('prc.webapp.name')))]",
-    "repWebAppNameTidy": "[toLower(trim(parameters('rep.webapp.name')))]",
+    "repWebAppNameTidy": "[toLower(trim(parameters('repWebappName')))]",
     "dbServerNameTidy": "[toLower(trim(parameters('sqlserverName')))]",
     "webDbServerNameTidy": "[toLower(trim(parameters('webSqlserverName')))]",
     "coreDbNameTidy": "[toLower(trim(parameters('coreSqldatabaseName')))]",
@@ -26,7 +26,7 @@
     "trackingHistoryMongoDbConnStrTidy": "[trim(parameters('trackingHistoryMongodbConnectionstring'))]",
     "trackingContactMongoDbConnStrTidy": "[trim(parameters('trackingContactMongodbConnectionstring'))]",
     "searchServiceNameTidy": "[toLower(trim(parameters('searchserviceName')))]",
-    "redisCacheNameTidy": "[toLower(trim(parameters('rediscache.name')))]",
+    "redisCacheNameTidy": "[toLower(trim(parameters('rediscacheName')))]",
     "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsightsName')))]",
     "licenseXml": "[parameters('licenseXml')]"
   },
@@ -39,27 +39,27 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "cm.hostingplan.name": {
+    "cmHostingplanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cm-hp')]"
     },
-    "cd.hostingplan.name": {
+    "cdHostingplanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cd-hp')]"
     },
-    "prc.hostingplan.name": {
+    "prcHostingplanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-prc-hp')]"
     },
-    "rep.hostingplan.name": {
+    "repHostingplanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-rep-hp')]"
     },
-    "cm.webapp.name": {
+    "cmWebappName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cm')]"
     },
-    "cd.webapp.name": {
+    "cdWebappName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cd')]"
     },
@@ -67,20 +67,20 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-prc')]"
     },
-    "rep.webapp.name": {
+    "repWebappName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-rep')]"
     },
-    "cm.msdeploy.packageurl": {
+    "cmMsdeployPackageurl": {
       "type": "securestring"
     },
-    "cd.msdeploy.packageurl": {
+    "cdMsdeployPackageurl": {
       "type": "securestring"
     },
-    "prc.msdeploy.packageurl": {
+    "prcMsdeployPackageurl": {
       "type": "securestring"
     },
-    "rep.msdeploy.packageurl": {
+    "repMsdeployPackageurl": {
       "type": "securestring"
     },
     "sqlserverName": {
@@ -125,132 +125,132 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-reporting-db')]"
     },
-    "cm.core.sqldatabase.username": {
+    "cmCoreSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cm-core-', deployment().name, '-user')]"
     },
-    "cm.core.sqldatabase.password": {
+    "cmCoreSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cm-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cm.master.sqldatabase.username": {
+    "cmMasterSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cm-master-', deployment().name, '-user')]"
     },
-    "cm.master.sqldatabase.password": {
+    "cmMasterSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cm-master')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cm.web.sqldatabase.username": {
+    "cmWebSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cm-web-', deployment().name, '-user')]"
     },
-    "cm.web.sqldatabase.password": {
+    "cmWebSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cm-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cd.core.sqldatabase.username": {
+    "cdCoreSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cd-core-', deployment().name, '-user')]"
     },
-    "cd.core.sqldatabase.password": {
+    "cdCoreSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cd-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "cd.web.sqldatabase.username": {
+    "cdWebSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('cd-web-', deployment().name, '-user')]"
     },
-    "cd.web.sqldatabase.password": {
+    "cdWebSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('cd-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "prc.core.sqldatabase.username": {
+    "prcCoreSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('prc-core-', deployment().name, '-user')]"
     },
-    "prc.core.sqldatabase.password": {
+    "prcCoreSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('prc-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "prc.master.sqldatabase.username": {
+    "prcMasterSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('prc-master-', deployment().name, '-user')]"
     },
-    "prc.master.sqldatabase.password": {
+    "prcMasterSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('prc-master')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "prc.web.sqldatabase.username": {
+    "prcWebSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('prc-web-', deployment().name, '-user')]"
     },
-    "prc.web.sqldatabase.password": {
+    "prcWebSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('prc-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "prc.reporting.sqldatabase.username": {
+    "prcReportingSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('prc-reporting-', deployment().name, '-user')]"
     },
-    "prc.reporting.sqldatabase.password": {
+    "prcReportingSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('prc-reporting')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "rep.core.sqldatabase.username": {
+    "repCoreSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('rep-core-', deployment().name, '-user')]"
     },
-    "rep.core.sqldatabase.password": {
+    "repCoreSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('rep-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "rep.master.sqldatabase.username": {
+    "repMasterSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('rep-master-', deployment().name, '-user')]"
     },
-    "rep.master.sqldatabase.password": {
+    "repMasterSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('rep-master')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "rep.web.sqldatabase.username": {
+    "repWebSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('rep-web-', deployment().name, '-user')]"
     },
-    "rep.web.sqldatabase.password": {
+    "repWebSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('rep-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "rep.reporting.sqldatabase.username": {
+    "repReportingSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('rep-reporting-', deployment().name, '-user')]"
     },
-    "rep.reporting.sqldatabase.password": {
+    "repReportingSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('rep-reporting')), '@', uniqueString(parameters('sqlserverPassword')))]"
@@ -271,7 +271,7 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-as')]"
     },
-    "rediscache.name": {
+    "rediscacheName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-redis')]"
     },
@@ -284,35 +284,35 @@
       "defaultValue": "East US",
       "allowedValues": [ "East US", "South Central US", "North Europe", "West Europe" ]
     },
-    "cm.hostingplan.skuname": {
+    "cmHostingplanSkuname": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "cm.hostingplan.skucapacity": {
+    "cmHostingplanSkucapacity": {
       "type": "int",
       "defaultValue": 1
     },
-    "cd.hostingplan.skuname": {
+    "cdHostingplanSkuname": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "cd.hostingplan.skucapacity": {
+    "cdHostingplanSkucapacity": {
       "type": "int",
       "defaultValue": 1
     },
-    "prc.hostingplan.skuname": {
+    "prcHostingplanSkuname": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "prc.hostingplan.skucapacity": {
+    "prcHostingplanSkucapacity": {
       "type": "int",
       "defaultValue": 1
     },
-    "rep.hostingplan.skuname": {
+    "repHostingplanSkuname": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "rep.hostingplan.skucapacity": {
+    "repHostingplanSkucapacity": {
       "type": "int",
       "defaultValue": 1
     },
@@ -348,15 +348,15 @@
       "type": "int",
       "defaultValue": 1
     },
-    "rediscache.skuname": {
+    "rediscacheSkuname": {
       "type": "string",
       "defaultValue": "Basic"
     },
-    "rediscache.skufamily": {
+    "rediscacheSkufamily": {
       "type": "string",
       "defaultValue": "C"
     },
-    "rediscache.skucapacity": {
+    "rediscacheSkucapacity": {
       "type": "string",
       "defaultValue": "0"
     },
@@ -369,11 +369,11 @@
     "licenseXml": {
       "type": "securestring"
     },
-    "security.clientIp": {
+    "securityClientIp": {
       "type": "string",
       "defaultValue": "0.0.0.0"
     },
-    "security.clientIpMask": {
+    "securityClientIpMask": {
       "type": "string",
       "defaultValue": "0.0.0.0"
     },
@@ -393,8 +393,8 @@
       "name": "[variables('cmHostingPlanNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "sku": {
-        "name": "[parameters('cm.hostingplan.skuname')]",
-        "capacity": "[parameters('cm.hostingplan.skucapacity')]"
+        "name": "[parameters('cmHostingplanSkuname')]",
+        "capacity": "[parameters('cmHostingplanSkucapacity')]"
       },
       "properties": {
         "name": "[variables('cmHostingPlanNameTidy')]"
@@ -409,8 +409,8 @@
       "name": "[variables('cdHostingPlanNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "sku": {
-        "name": "[parameters('cd.hostingplan.skuname')]",
-        "capacity": "[parameters('cd.hostingplan.skucapacity')]"
+        "name": "[parameters('cdHostingplanSkuname')]",
+        "capacity": "[parameters('cdHostingplanSkucapacity')]"
       },
       "properties": {
         "name": "[variables('cdHostingPlanNameTidy')]"
@@ -426,8 +426,8 @@
       "name": "[variables('prcHostingPlanNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "sku": {
-        "name": "[parameters('prc.hostingplan.skuname')]",
-        "capacity": "[parameters('prc.hostingplan.skucapacity')]"
+        "name": "[parameters('prcHostingplanSkuname')]",
+        "capacity": "[parameters('prcHostingplanSkucapacity')]"
       },
       "properties": {
         "name": "[variables('prcHostingPlanNameTidy')]"
@@ -443,8 +443,8 @@
       "name": "[variables('repHostingPlanNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "sku": {
-        "name": "[parameters('rep.hostingplan.skuname')]",
-        "capacity": "[parameters('rep.hostingplan.skucapacity')]"
+        "name": "[parameters('repHostingplanSkuname')]",
+        "capacity": "[parameters('repHostingplanSkucapacity')]"
       },
       "properties": {
         "name": "[variables('repHostingPlanNameTidy')]"
@@ -492,24 +492,24 @@
             "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('repDbNameTidy'))]" 
           ],
           "properties": {
-            "packageUri": "[parameters('cm.msdeploy.packageurl')]",
+            "packageUri": "[parameters('cmMsdeployPackageurl')]",
             "dbType": "SQL",
             "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cmWebAppNameTidy')]",
               "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
-              "Core DB User Name": "[parameters('cm.core.sqldatabase.username')]",
-              "Core DB Password": "[parameters('cm.core.sqldatabase.password')]",
+              "Core DB User Name": "[parameters('cmCoreSqldatabaseUsername')]",
+              "Core DB Password": "[parameters('cmCoreSqldatabasePassword')]",
               "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cm.core.sqldatabase.username'), ';Password=', parameters('cm.core.sqldatabase.password'), ';')]",
-              "Master DB User Name": "[parameters('cm.master.sqldatabase.username')]",
-              "Master DB Password": "[parameters('cm.master.sqldatabase.password')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cmCoreSqldatabaseUsername'), ';Password=', parameters('cmCoreSqldatabasePassword'), ';')]",
+              "Master DB User Name": "[parameters('cmMasterSqldatabaseUsername')]",
+              "Master DB Password": "[parameters('cmMasterSqldatabasePassword')]",
               "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('cm.master.sqldatabase.username'), ';Password=', parameters('cm.master.sqldatabase.password'), ';')]",
-              "Web DB User Name": "[parameters('cm.web.sqldatabase.username')]",
-              "Web DB Password": "[parameters('cm.web.sqldatabase.password')]",
+              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('cmMasterSqldatabaseUsername'), ';Password=', parameters('cmMasterSqldatabasePassword'), ';')]",
+              "Web DB User Name": "[parameters('cmWebSqldatabaseUsername')]",
+              "Web DB Password": "[parameters('cmWebSqldatabasePassword')]",
               "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
-              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cm.web.sqldatabase.username'), ';Password=', parameters('cm.web.sqldatabase.password'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cmWebSqldatabaseUsername'), ';Password=', parameters('cmWebSqldatabasePassword'), ';')]",
               "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Analytics Connection String": "[variables('analyticsMongoDbConnStrTidy')]",
@@ -521,8 +521,8 @@
               "Application Insights Role": "CM",
               "KeepAlive Url": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('cmWebAppNameTidy'))).hostNames[0], '/sitecore/service/keepalive.aspx')]",
               "License Xml": "[variables('licenseXml')]",
-              "IP Security Client IP": "[parameters('security.clientIp')]",
-              "IP Security Client IP Mask": "[parameters('security.clientIpMask')]"
+              "IP Security Client IP": "[parameters('securityClientIp')]",
+              "IP Security Client IP Mask": "[parameters('securityClientIpMask')]"
             }
           }
         }
@@ -566,20 +566,20 @@
             "[concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'), '/databases/', variables('webDbNameTidy'))]"
           ],
           "properties": {
-            "packageUri": "[parameters('cd.msdeploy.packageurl')]",
+            "packageUri": "[parameters('cdMsdeployPackageurl')]",
             "dbType": "SQL",
             "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cdWebAppNameTidy')]",
               "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
-              "Core DB User Name": "[parameters('cd.core.sqldatabase.username')]",
-              "Core DB Password": "[parameters('cd.core.sqldatabase.password')]",
+              "Core DB User Name": "[parameters('cdCoreSqldatabaseUsername')]",
+              "Core DB Password": "[parameters('cdCoreSqldatabasePassword')]",
               "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cd.core.sqldatabase.username'), ';Password=', parameters('cd.core.sqldatabase.password'), ';')]",
-              "Web DB User Name": "[parameters('cd.web.sqldatabase.username')]",
-              "Web DB Password": "[parameters('cd.web.sqldatabase.password')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('cdCoreSqldatabaseUsername'), ';Password=', parameters('cdCoreSqldatabasePassword'), ';')]",
+              "Web DB User Name": "[parameters('cdWebSqldatabaseUsername')]",
+              "Web DB Password": "[parameters('cdWebSqldatabasePassword')]",
               "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
-              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cd.web.sqldatabase.username'), ';Password=', parameters('cd.web.sqldatabase.password'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('cdWebSqldatabaseUsername'), ';Password=', parameters('cdWebSqldatabasePassword'), ';')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Analytics Connection String": "[variables('analyticsMongoDbConnStrTidy')]",
               "Tracking Live Connection String": "[variables('trackingLiveMongoDbConnStrTidy')]",
@@ -633,28 +633,28 @@
             "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('repDbNameTidy'))]"
           ],
           "properties": {
-            "packageUri": "[parameters('prc.msdeploy.packageurl')]",
+            "packageUri": "[parameters('prcMsdeployPackageurl')]",
             "dbType": "SQL",
             "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('prcWebAppNameTidy')]",
               "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
-              "Core DB User Name": "[parameters('prc.core.sqldatabase.username')]",
-              "Core DB Password": "[parameters('prc.core.sqldatabase.password')]",
+              "Core DB User Name": "[parameters('prcCoreSqldatabaseUsername')]",
+              "Core DB Password": "[parameters('prcCoreSqldatabasePassword')]",
               "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('prc.core.sqldatabase.username'), ';Password=', parameters('prc.core.sqldatabase.password'), ';')]",
-              "Master DB User Name": "[parameters('prc.master.sqldatabase.username')]",
-              "Master DB Password": "[parameters('prc.master.sqldatabase.password')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('prcCoreSqldatabaseUsername'), ';Password=', parameters('prcCoreSqldatabasePassword'), ';')]",
+              "Master DB User Name": "[parameters('prcMasterSqldatabaseUsername')]",
+              "Master DB Password": "[parameters('prcMasterSqldatabasePassword')]",
               "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('prc.master.sqldatabase.username'), ';Password=', parameters('prc.master.sqldatabase.password'), ';')]",
-              "Web DB User Name": "[parameters('prc.web.sqldatabase.username')]",
-              "Web DB Password": "[parameters('prc.web.sqldatabase.password')]",
+              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('prcMasterSqldatabaseUsername'), ';Password=', parameters('prcMasterSqldatabasePassword'), ';')]",
+              "Web DB User Name": "[parameters('prcWebSqldatabaseUsername')]",
+              "Web DB Password": "[parameters('prcWebSqldatabasePassword')]",
               "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
-              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('prc.web.sqldatabase.username'), ';Password=', parameters('prc.web.sqldatabase.password'), ';')]",
-              "Reporting DB User Name": "[parameters('prc.reporting.sqldatabase.username')]",
-              "Reporting DB Password": "[parameters('prc.reporting.sqldatabase.password')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('prcWebSqldatabaseUsername'), ';Password=', parameters('prcWebSqldatabasePassword'), ';')]",
+              "Reporting DB User Name": "[parameters('prcReportingSqldatabaseUsername')]",
+              "Reporting DB Password": "[parameters('prcReportingSqldatabasePassword')]",
               "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('prc.reporting.sqldatabase.username'), ';Password=', parameters('prc.reporting.sqldatabase.password'), ';')]",
+              "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('prcReportingSqldatabaseUsername'), ';Password=', parameters('prcReportingSqldatabasePassword'), ';')]",
               "Analytics Connection String": "[variables('analyticsMongoDbConnStrTidy')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Tracking Live Connection String": "[variables('trackingLiveMongoDbConnStrTidy')]",
@@ -664,8 +664,8 @@
               "Application Insights Role": "Processing",
               "KeepAlive Url": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('prcWebAppNameTidy'))).hostNames[0], '/sitecore/service/keepalive.aspx')]",
               "License Xml": "[variables('licenseXml')]",
-              "IP Security Client IP": "[parameters('security.clientIp')]",
-              "IP Security Client IP Mask": "[parameters('security.clientIpMask')]"
+              "IP Security Client IP": "[parameters('securityClientIp')]",
+              "IP Security Client IP Mask": "[parameters('securityClientIpMask')]"
             }
           }
         }
@@ -710,28 +710,28 @@
             "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('repDbNameTidy'))]"
           ],
           "properties": {
-            "packageUri": "[parameters('rep.msdeploy.packageurl')]",
+            "packageUri": "[parameters('repMsdeployPackageurl')]",
             "dbType": "SQL",
             "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('repWebAppNameTidy')]",
               "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
-              "Core DB User Name": "[parameters('rep.core.sqldatabase.username')]",
-              "Core DB Password": "[parameters('rep.core.sqldatabase.password')]",
+              "Core DB User Name": "[parameters('repCoreSqldatabaseUsername')]",
+              "Core DB Password": "[parameters('repCoreSqldatabasePassword')]",
               "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('rep.core.sqldatabase.username'), ';Password=', parameters('rep.core.sqldatabase.password'), ';')]",
-              "Master DB User Name": "[parameters('rep.master.sqldatabase.username')]",
-              "Master DB Password": "[parameters('rep.master.sqldatabase.password')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('repCoreSqldatabaseUsername'), ';Password=', parameters('repCoreSqldatabasePassword'), ';')]",
+              "Master DB User Name": "[parameters('repMasterSqldatabaseUsername')]",
+              "Master DB Password": "[parameters('repMasterSqldatabasePassword')]",
               "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('rep.master.sqldatabase.username'), ';Password=', parameters('rep.master.sqldatabase.password'), ';')]",
-              "Web DB User Name": "[parameters('rep.web.sqldatabase.username')]",
-              "Web DB Password": "[parameters('rep.web.sqldatabase.password')]",
+              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('repMasterSqldatabaseUsername'), ';Password=', parameters('repMasterSqldatabasePassword'), ';')]",
+              "Web DB User Name": "[parameters('repWebSqldatabaseUsername')]",
+              "Web DB Password": "[parameters('repWebSqldatabasePassword')]",
               "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
-              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('rep.web.sqldatabase.username'), ';Password=', parameters('rep.web.sqldatabase.password'), ';')]",
-              "Reporting DB User Name": "[parameters('rep.reporting.sqldatabase.username')]",
-              "Reporting DB Password": "[parameters('rep.reporting.sqldatabase.password')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('repWebSqldatabaseUsername'), ';Password=', parameters('repWebSqldatabasePassword'), ';')]",
+              "Reporting DB User Name": "[parameters('repReportingSqldatabaseUsername')]",
+              "Reporting DB Password": "[parameters('repReportingSqldatabasePassword')]",
               "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
-              "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('rep.reporting.sqldatabase.username'), ';Password=', parameters('rep.reporting.sqldatabase.password'), ';')]",
+              "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('repReportingSqldatabaseUsername'), ';Password=', parameters('repReportingSqldatabasePassword'), ';')]",
               "Reporting Service Api Key": "[parameters('rep.authentication.apikey')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Analytics Connection String": "[variables('analyticsMongoDbConnStrTidy')]",
@@ -885,9 +885,9 @@
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
-          "name": "[parameters('rediscache.skuname')]",
-          "family": "[parameters('rediscache.skufamily')]",
-          "capacity": "[parameters('rediscache.skucapacity')]"
+          "name": "[parameters('rediscacheSkuname')]",
+          "family": "[parameters('rediscacheSkufamily')]",
+          "capacity": "[parameters('rediscacheSkucapacity')]"
         },
         "enableNonSslPort": false
       },

--- a/Sitecore 8.2.1/xp/azuredeploy.json
+++ b/Sitecore 8.2.1/xp/azuredeploy.json
@@ -13,7 +13,7 @@
     "repHostingPlanNameTidy": "[toLower(trim(parameters('repHostingplanName')))]",
     "cmWebAppNameTidy": "[toLower(trim(parameters('cmWebappName')))]",
     "cdWebAppNameTidy": "[toLower(trim(parameters('cdWebappName')))]",
-    "prcWebAppNameTidy": "[toLower(trim(parameters('prc.webapp.name')))]",
+    "prcWebAppNameTidy": "[toLower(trim(parameters('prcWebappName')))]",
     "repWebAppNameTidy": "[toLower(trim(parameters('repWebappName')))]",
     "dbServerNameTidy": "[toLower(trim(parameters('sqlserverName')))]",
     "webDbServerNameTidy": "[toLower(trim(parameters('webSqlserverName')))]",
@@ -63,7 +63,7 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cd')]"
     },
-    "prc.webapp.name": {
+    "prcWebappName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-prc')]"
     },
@@ -382,7 +382,7 @@
       "minLength": 8,
       "maxLength": 128
     },
-    "rep.authentication.apikey": {
+    "repAuthenticationApikey": {
       "type": "securestring",
       "minLength": 32
     }
@@ -516,7 +516,7 @@
               "Tracking Live Connection String": "[variables('trackingLiveMongoDbConnStrTidy')]",
               "Tracking Contact Connection String": "[variables('trackingContactMongoDbConnStrTidy')]",
               "Reporting Service Url": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('repWebAppNameTidy'))).hostNames[0])]",
-              "Reporting Service Api Key": "[parameters('rep.authentication.apikey')]",
+              "Reporting Service Api Key": "[parameters('repAuthenticationApikey')]",
               "Application Insights Instrumentation Key": "[reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))).InstrumentationKey]",
               "Application Insights Role": "CM",
               "KeepAlive Url": "[concat('https://', reference(resourceId('Microsoft.Web/sites', variables('cmWebAppNameTidy'))).hostNames[0], '/sitecore/service/keepalive.aspx')]",
@@ -732,7 +732,7 @@
               "Reporting DB Password": "[parameters('repReportingSqldatabasePassword')]",
               "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
               "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('repReportingSqldatabaseUsername'), ';Password=', parameters('repReportingSqldatabasePassword'), ';')]",
-              "Reporting Service Api Key": "[parameters('rep.authentication.apikey')]",
+              "Reporting Service Api Key": "[parameters('repAuthenticationApikey')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Analytics Connection String": "[variables('analyticsMongoDbConnStrTidy')]",
               "Tracking Live Connection String": "[variables('trackingLiveMongoDbConnStrTidy')]",

--- a/Sitecore 8.2.1/xp/azuredeploy.parameters.json
+++ b/Sitecore 8.2.1/xp/azuredeploy.parameters.json
@@ -2,28 +2,28 @@
   "deploymentId": {
     "value": ""
   },
-  "sitecore.admin.password": {
+  "sitecoreAdminPassword": {
     "value": ""
   },
   "rep.authentication.apikey": {
 	"value": ""
   },
-  "analytics.mongodb.connectionstring": {
+  "analyticsMongodbConnectionstring": {
     "value": ""
   },
-  "tracking.live.mongodb.connectionstring": {
+  "trackingLiveMongodbConnectionstring": {
     "value": ""
   },
-  "tracking.history.mongodb.connectionstring": {
+  "trackingHistoryMongodbConnectionstring": {
     "value": ""
   },
-  "tracking.contact.mongodb.connectionstring": {
+  "trackingContactMongodbConnectionstring": {
     "value": ""
   },
-  "sqlserver.login": {
+  "sqlserverLogin": {
     "value": ""
   },
-  "sqlserver.password": {
+  "sqlserverPassword": {
     "value": ""
   },
   "cm.msdeploy.packageurl": {

--- a/Sitecore 8.2.1/xp/azuredeploy.parameters.json
+++ b/Sitecore 8.2.1/xp/azuredeploy.parameters.json
@@ -26,16 +26,16 @@
   "sqlserverPassword": {
     "value": ""
   },
-  "cm.msdeploy.packageurl": {
+  "cmMsdeployPackageurl": {
     "value": ""
   },
-  "cd.msdeploy.packageurl": {
+  "cdMsdeployPackageurl": {
     "value": ""
   },
-  "prc.msdeploy.packageurl": {
+  "prcMsdeployPackageurl": {
     "value": ""
   },
-  "rep.msdeploy.packageurl": {
+  "repMsdeployPackageurl": {
     "value": ""
   },
   "licenseXml": {

--- a/Sitecore 8.2.1/xp/azuredeploy.parameters.json
+++ b/Sitecore 8.2.1/xp/azuredeploy.parameters.json
@@ -5,7 +5,7 @@
   "sitecoreAdminPassword": {
     "value": ""
   },
-  "rep.authentication.apikey": {
+  "repAuthenticationApikey": {
 	"value": ""
   },
   "analyticsMongodbConnectionstring": {

--- a/Sitecore 8.2.1/xp0/README.md
+++ b/Sitecore 8.2.1/xp0/README.md
@@ -20,11 +20,11 @@ The **deploymentId** and **licenseXml** parameters are filled in by the PowerShe
 
 | Parameter                                 | Description
 --------------------------------------------|------------------------------------------------
-| sqlserver.login                           | The name of the administrator account for the newly created Azure SQL server.
-| sqlserver.password                        | The password for the administrator account for Azure SQL server.
-| sitecore.admin.password                   | The new password for the Sitecore **admin** account.
-| single.msdeploy.packageurl                | The blob storage url to a Sitecore XP Single Instance Web Deploy package.
-| analytics.mongodb.connectionstring        | A MongoDB connection string for the analytics database.
-| tracking.live.mongodb.connectionstring    | A MongoDB connection string for the tracking.live database.
-| tracking.history.mongodb.connectionstring | A MongoDB connection string for the tracking.history database.
-| tracking.contact.mongodb.connectionstring | A MongoDB connection string for the tracking.contact database.
+| sqlserverLogin                            | The name of the administrator account for the newly created Azure SQL server.
+| sqlserverPassword                         | The password for the administrator account for Azure SQL server.
+| sitecoreAdminPassword                     | The new password for the Sitecore **admin** account.
+| singleMsdeployPackageurl                  | The blob storage url to a Sitecore XP Single Instance Web Deploy package.
+| analyticsMongodbConnectionstring          | A MongoDB connection string for the analytics database.
+| trackingLiveMongodbConnectionstring       | A MongoDB connection string for the tracking.live database.
+| trackingHistoryMongodbConnectionstring    | A MongoDB connection string for the tracking.history database.
+| trackingContactMongodbConnectionstring    | A MongoDB connection string for the tracking.contact database.

--- a/Sitecore 8.2.1/xp0/azuredeploy.json
+++ b/Sitecore 8.2.1/xp0/azuredeploy.json
@@ -6,20 +6,20 @@
     "dbApiVersion": "2014-04-01-preview",
     "searchApiVersion": "2015-02-28",
     "appInsightsApiVersion": "2014-08-01",
-    "hostingPlanNameTidy": "[toLower(trim(parameters('single.hostingplan.name')))]",
-    "webAppNameTidy": "[toLower(trim(parameters('single.webapp.name')))]",
-    "dbServerNameTidy": "[toLower(trim(parameters('sqlserver.name')))]",
-    "webDbServerNameTidy": "[toLower(trim(parameters('web.sqlserver.name')))]",
-    "coreDbNameTidy": "[toLower(trim(parameters('core.sqldatabase.name')))]",
-    "webDbNameTidy": "[toLower(trim(parameters('web.sqldatabase.name')))]",
-    "masterDbNameTidy": "[toLower(trim(parameters('master.sqldatabase.name')))]",
-    "repDbNameTidy": "[toLower(trim(parameters('reporting.sqldatabase.name')))]",
-    "analyticsMongoDbConnStrTidy": "[trim(parameters('analytics.mongodb.connectionstring'))]",
-    "trackingLiveMongoDbConnStrTidy": "[trim(parameters('tracking.live.mongodb.connectionstring'))]",
-    "trackingHistoryMongoDbConnStrTidy": "[trim(parameters('tracking.history.mongodb.connectionstring'))]",
-    "trackingContactMongoDbConnStrTidy": "[trim(parameters('tracking.contact.mongodb.connectionstring'))]",
-    "searchServiceNameTidy": "[toLower(trim(parameters('searchservice.name')))]",
-    "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsights.name')))]",
+    "hostingPlanNameTidy": "[toLower(trim(parameters('singleHostingplanName')))]",
+    "webAppNameTidy": "[toLower(trim(parameters('singleWebappName')))]",
+    "dbServerNameTidy": "[toLower(trim(parameters('sqlserverName')))]",
+    "webDbServerNameTidy": "[toLower(trim(parameters('webSqlserverName')))]",
+    "coreDbNameTidy": "[toLower(trim(parameters('coreSqldatabaseName')))]",
+    "webDbNameTidy": "[toLower(trim(parameters('webSqldatabaseName')))]",
+    "masterDbNameTidy": "[toLower(trim(parameters('masterSqldatabaseName')))]",
+    "repDbNameTidy": "[toLower(trim(parameters('reportingSqldatabaseName')))]",
+    "analyticsMongoDbConnStrTidy": "[trim(parameters('analyticsMongodbConnectionstring'))]",
+    "trackingLiveMongoDbConnStrTidy": "[trim(parameters('trackingLiveMongodbConnectionstring'))]",
+    "trackingHistoryMongoDbConnStrTidy": "[trim(parameters('trackingHistoryMongodbConnectionstring'))]",
+    "trackingContactMongoDbConnStrTidy": "[trim(parameters('trackingContactMongodbConnectionstring'))]",
+    "searchServiceNameTidy": "[toLower(trim(parameters('searchserviceName')))]",
+    "appInsightsNameTidy": "[toLower(trim(parameters('applicationinsightsName')))]",
     "licenseXml": "[parameters('licenseXml')]"
   },
   "parameters": {
@@ -31,161 +31,161 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-    "single.hostingplan.name": {
+    "singleHostingplanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-single-hp')]"
     },
-    "single.webapp.name": {
+    "singleWebappName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-single')]"
     },
-    "single.msdeploy.packageurl": {
+    "singleMsdeployPackageurl": {
       "type": "securestring"
     },
-    "sqlserver.name": {
+    "sqlserverName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-sql')]"
     },
-    "sqlserver.login": {
+    "sqlserverLogin": {
       "type": "string",
       "minLength": 1
     },
-    "sqlserver.password": {
+    "sqlserverPassword": {
       "type": "securestring",
       "minLength": 8
     },
-    "web.sqlserver.name": {
+    "webSqlserverName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-web-sql')]"
     },
-    "web.sqlserver.login": {
+    "webSqlserverLogin": {
       "type": "string",
       "minLength": 1,
-      "defaultValue": "[parameters('sqlserver.login')]"
+      "defaultValue": "[parameters('sqlserverLogin')]"
     },
-    "web.sqlserver.password": {
+    "webSqlserverPassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[parameters('sqlserver.password')]"
+      "defaultValue": "[parameters('sqlserverPassword')]"
     },
-    "single.core.sqldatabase.username": {
+    "singleCoreSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('single-core-', deployment().name, '-user')]"
     },
-    "single.core.sqldatabase.password": {
+    "singleCoreSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('single-core')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('single-core')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "single.master.sqldatabase.username": {
+    "singleMasterSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('single-master-', deployment().name, '-user')]"
     },
-    "single.master.sqldatabase.password": {
+    "singleMasterSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('single-master')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('single-master')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "single.web.sqldatabase.username": {
+    "singleWebSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('single-web-', deployment().name, '-user')]"
     },
-    "single.web.sqldatabase.password": {
+    "singleWebSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('single-web')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('single-web')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "single.reporting.sqldatabase.username": {
+    "singleReportingSqldatabaseUsername": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat('single-reporting-', deployment().name, '-user')]"
     },
-    "single.reporting.sqldatabase.password": {
+    "singleReportingSqldatabasePassword": {
       "type": "securestring",
       "minLength": 8,
-      "defaultValue": "[concat(toUpper(uniqueString('single-reporting')), '@', uniqueString(parameters('sqlserver.password')))]"
+      "defaultValue": "[concat(toUpper(uniqueString('single-reporting')), '@', uniqueString(parameters('sqlserverPassword')))]"
     },
-    "core.sqldatabase.name": {
+    "coreSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-core-db')]"
     },
-    "master.sqldatabase.name": {
+    "masterSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-master-db')]"
     },
-    "web.sqldatabase.name": {
+    "webSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-web-db')]"
     },
-    "reporting.sqldatabase.name": {
+    "reportingSqldatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-reporting-db')]"
     },
-    "analytics.mongodb.connectionstring": {
+    "analyticsMongodbConnectionstring": {
       "type": "securestring"
     },
-    "tracking.live.mongodb.connectionstring": {
+    "trackingLiveMongodbConnectionstring": {
       "type": "securestring"
     },
-    "tracking.history.mongodb.connectionstring": {
+    "trackingHistoryMongodbConnectionstring": {
       "type": "securestring"
     },
-    "tracking.contact.mongodb.connectionstring": {
+    "trackingContactMongodbConnectionstring": {
       "type": "securestring"
     },
-    "searchservice.name": {
+    "searchserviceName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-as')]"
     },
-    "applicationinsights.name": {
+    "applicationinsightsName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-ai')]"
     },
-    "applicationinsights.location": {
+    "applicationinsightsLocation": {
       "type": "string",
       "defaultValue": "East US",
       "allowedValues": [ "East US", "South Central US", "North Europe", "West Europe" ]
     },
-    "single.hostingplan.skuname": {
+    "singleHostingplanSkuname": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "single.hostingplan.skucapacity": {
+    "singleHostingplanSkucapacity": {
       "type": "int",
       "defaultValue": 1
     },
-    "searchservice.skuname": {
+    "searchserviceSkuname": {
       "type": "string",
       "defaultValue": "Standard"
     },
-    "sqlserver.version": {
+    "sqlserverVersion": {
       "type": "string",
       "defaultValue": "12.0"
     },
-    "sqldatabase.collation": {
+    "sqldatabaseCollation": {
       "type": "string",
       "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
     },
-    "sqldatabase.edition": {
+    "sqldatabaseEdition": {
       "type": "string",
       "defaultValue": "Standard"
     },
-    "sqldatabase.maxsize": {
+    "sqldatabaseMaxsize": {
       "type": "string",
       "defaultValue": "10737418240"
     },
-    "sqldatabase.serviceobjectivelevel": {
+    "sqldatabaseServiceobjectivelevel": {
       "type": "string",
       "defaultValue": "S1"
     },
-    "searchservice.replicacount": {
+    "searchserviceReplicacount": {
       "type": "int",
       "defaultValue": 1
     },
-    "searchservice.partitioncount": {
+    "searchservicePartitioncount": {
       "type": "int",
       "defaultValue": 1
     },
@@ -198,7 +198,7 @@
     "licenseXml": {
       "type": "securestring"
     },
-    "sitecore.admin.password": {
+    "sitecoreAdminPassword": {
       "type": "securestring",
       "minLength": 8,
       "maxLength": 128
@@ -210,8 +210,8 @@
       "name": "[variables('hostingPlanNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "sku": {
-        "name": "[parameters('single.hostingplan.skuname')]",
-        "capacity": "[parameters('single.hostingplan.skucapacity')]"
+        "name": "[parameters('singleHostingplanSkuname')]",
+        "capacity": "[parameters('singleHostingplanSkucapacity')]"
       },
       "properties": {
         "name": "[variables('hostingPlanNameTidy')]"
@@ -249,28 +249,28 @@
           "apiVersion": "[variables('webApiVersion')]",
           "dependsOn": [ "[concat('Microsoft.Web/sites/', variables('webAppNameTidy'))]", "[resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy'))]", "[resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('coreDbNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('masterDbNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'), '/databases/', variables('webDbNameTidy'))]", "[concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'), '/databases/', variables('repDbNameTidy'))]" ],
           "properties": {
-            "packageUri": "[parameters('single.msdeploy.packageurl')]",
+            "packageUri": "[parameters('singleMsdeployPackageurl')]",
             "dbType": "SQL",
-            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserver.login'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserver.password'), ';')]",
+            "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=master;User Id=', parameters('sqlserverLogin'), '@', variables('dbServerNameTidy'), ';Password=', parameters('sqlserverPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('webAppNameTidy')]",
-              "Sitecore Admin New Password": "[parameters('sitecore.admin.password')]",
-              "Core DB User Name": "[parameters('single.core.sqldatabase.username')]",
-              "Core DB Password": "[parameters('single.core.sqldatabase.password')]",
-              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
-              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('single.core.sqldatabase.username'), ';Password=', parameters('single.core.sqldatabase.password'), ';')]",
-              "Master DB User Name": "[parameters('single.master.sqldatabase.username')]",
-              "Master DB Password": "[parameters('single.master.sqldatabase.password')]",
-              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
-              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('single.master.sqldatabase.username'), ';Password=', parameters('single.master.sqldatabase.password'), ';')]",
-              "Web DB User Name": "[parameters('single.web.sqldatabase.username')]",
-              "Web DB Password": "[parameters('single.web.sqldatabase.password')]",
-              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('web.sqlserver.login'), ';Password=', parameters('web.sqlserver.password'), ';')]",
-              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('single.web.sqldatabase.username'), ';Password=', parameters('single.web.sqldatabase.password'), ';')]",
-              "Reporting DB User Name": "[parameters('single.reporting.sqldatabase.username')]",
-              "Reporting DB Password": "[parameters('single.reporting.sqldatabase.password')]",
-              "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserver.login'), ';Password=', parameters('sqlserver.password'), ';')]",
-              "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('single.reporting.sqldatabase.username'), ';Password=', parameters('single.reporting.sqldatabase.password'), ';')]",
+              "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
+              "Core DB User Name": "[parameters('singleCoreSqldatabaseUsername')]",
+              "Core DB Password": "[parameters('singleCoreSqldatabasePassword')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('coreDbNameTidy'),';User Id=', parameters('singleCoreSqldatabaseUsername'), ';Password=', parameters('singleCoreSqldatabasePassword'), ';')]",
+              "Master DB User Name": "[parameters('singleMasterSqldatabaseUsername')]",
+              "Master DB Password": "[parameters('singleMasterSqldatabasePassword')]",
+              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
+              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('masterDbNameTidy'),';User Id=', parameters('singleMasterSqldatabaseUsername'), ';Password=', parameters('singleMasterSqldatabasePassword'), ';')]",
+              "Web DB User Name": "[parameters('singleWebSqldatabaseUsername')]",
+              "Web DB Password": "[parameters('singleWebSqldatabasePassword')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('webSqlserverLogin'), ';Password=', parameters('webSqlserverPassword'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('webDbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('webDbNameTidy'),';User Id=', parameters('singleWebSqldatabaseUsername'), ';Password=', parameters('singleWebSqldatabasePassword'), ';')]",
+              "Reporting DB User Name": "[parameters('singleReportingSqldatabaseUsername')]",
+              "Reporting DB Password": "[parameters('singleReportingSqldatabasePassword')]",
+              "Reporting Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('sqlserverLogin'), ';Password=', parameters('sqlserverPassword'), ';')]",
+              "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', reference(concat('Microsoft.Sql/servers/', variables('dbServerNameTidy'))).fullyQualifiedDomainName, ',1433;Initial Catalog=',variables('repDbNameTidy'),';User Id=', parameters('singleReportingSqldatabaseUsername'), ';Password=', parameters('singleReportingSqldatabasePassword'), ';')]",
               "Analytics Connection String": "[variables('analyticsMongoDbConnStrTidy')]",
               "Cloud Search Connection String": "[concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey)]",
               "Tracking Live Connection String": "[variables('trackingLiveMongoDbConnStrTidy')]",
@@ -289,9 +289,9 @@
       "type": "Microsoft.Sql/servers",
       "apiVersion": "[variables('dbApiVersion')]",
       "properties": {
-        "administratorLogin": "[parameters('sqlserver.login')]",
-        "administratorLoginPassword": "[parameters('sqlserver.password')]",
-        "version": "[parameters('sqlserver.version')]"
+        "administratorLogin": "[parameters('sqlserverLogin')]",
+        "administratorLoginPassword": "[parameters('sqlserverPassword')]",
+        "version": "[parameters('sqlserverVersion')]"
       },
       "name": "[variables('dbServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -313,10 +313,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('coreDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -329,10 +329,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('masterDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -345,10 +345,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('repDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -363,9 +363,9 @@
       "type": "Microsoft.Sql/servers",
       "apiVersion": "[variables('dbApiVersion')]",
       "properties": {
-        "administratorLogin": "[parameters('web.sqlserver.login')]",
-        "administratorLoginPassword": "[parameters('web.sqlserver.password')]",
-        "version": "[parameters('sqlserver.version')]"
+        "administratorLogin": "[parameters('webSqlserverLogin')]",
+        "administratorLoginPassword": "[parameters('webSqlserverPassword')]",
+        "version": "[parameters('sqlserverVersion')]"
       },
       "name": "[variables('webDbServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -387,10 +387,10 @@
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "edition": "[parameters('sqldatabase.edition')]",
-            "collation": "[parameters('sqldatabase.collation')]",
-            "maxSizeBytes": "[parameters('sqldatabase.maxsize')]",
-            "requestedServiceObjectiveName": "[parameters('sqldatabase.serviceobjectivelevel')]"
+            "edition": "[parameters('sqldatabaseEdition')]",
+            "collation": "[parameters('sqldatabaseCollation')]",
+            "maxSizeBytes": "[parameters('sqldatabaseMaxsize')]",
+            "requestedServiceObjectiveName": "[parameters('sqldatabaseServiceobjectivelevel')]"
           },
           "name": "[variables('webDbNameTidy')]",
           "location": "[parameters('location')]",
@@ -408,10 +408,10 @@
       "location": "[parameters('location')]",
       "properties": {
         "sku": {
-          "name": "[toLower(parameters('searchservice.skuname'))]"
+          "name": "[toLower(parameters('searchserviceSkuname'))]"
         },
-        "replicaCount": "[parameters('searchservice.replicacount')]",
-        "partitionCount": "[parameters('searchservice.partitioncount')]"
+        "replicaCount": "[parameters('searchserviceReplicacount')]",
+        "partitionCount": "[parameters('searchservicePartitioncount')]"
       },
       "tags": {
         "provider": "[parameters('sitecoreTags').provider]"
@@ -421,7 +421,7 @@
       "type": "Microsoft.Insights/Components",
       "name": "[variables('appInsightsNameTidy')]",
       "apiVersion": "[variables('appInsightsApiVersion')]",
-      "location": "[parameters('applicationinsights.location')]",
+      "location": "[parameters('applicationinsightsLocation')]",
       "properties": {
         "ApplicationId": "[variables('appInsightsNameTidy')]",
         "Application_Type": "web"

--- a/Sitecore 8.2.1/xp0/azuredeploy.parameters.json
+++ b/Sitecore 8.2.1/xp0/azuredeploy.parameters.json
@@ -2,28 +2,28 @@
   "deploymentId": {
     "value": ""
   },
-  "sitecore.admin.password": {
+  "sitecoreAdminPassword": {
     "value": ""
   },
-  "analytics.mongodb.connectionstring": {
+  "analyticsMongodbConnectionstring": {
     "value": ""
   },
-  "tracking.live.mongodb.connectionstring": {
+  "trackingLiveMongodbConnectionstring": {
     "value": ""
   },
-  "tracking.history.mongodb.connectionstring": {
+  "trackingHistoryMongodbConnectionstring": {
     "value": ""
   },
-  "tracking.contact.mongodb.connectionstring": {
+  "trackingContactMongodbConnectionstring": {
     "value": ""
   },
-  "sqlserver.login": {
+  "sqlserverLogin": {
     "value": ""
   },
-  "sqlserver.password": {
+  "sqlserverPassword": {
     "value": ""
   },
-  "single.msdeploy.packageurl": {
+  "singleMsdeployPackageurl": {
     "value": ""
   },
   "licenseXml": {


### PR DESCRIPTION
Regarding the issue #4, I would like to propose to rename all the parameters containing 
> .[a-z]

 by 

> .[A-Z] 

What do you think?

Edit - 02/15/2017: since my issue #4 has been removed/hidden, let me explain here what is my approach around that:
* When we use `New-AzureRmResourceGroupDeployment` with inline parameters like `-sqlserver.login myLogin` we have an error message because of the `.`. I know we could use other alternatives like `-TemplateParameterObject` or `-TemplateParameterFile` like described [here](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-template-deploy#parameters), but could be a limitation.
* Furthermore, [best practices for templates parameters](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-template-best-practices#parameters) indicates: 
> 2. Parameter names should follow camelCasing.
