### PR TITLE
Fixed reading of the parameters from JSON. Fixed adding of the licenseXML contents to the parameters collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ $additionalParams = New-Object -TypeName Hashtable
 
 $params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json
 
+if ($params.parameters -ne $null)
+{
+     $params = $params.parameters
+}
+
 foreach($p in $params | Get-Member -MemberType *Property)
 {
     $additionalParams.Add($p.Name, $params.$($p.Name).value)

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ foreach($p in $params | Get-Member -MemberType *Property)
     $additionalParams.Add($p.Name, $params.$($p.Name).value)
 }
 
-$additionalParams.licenseXml = $licenseFileContent
-$additionalParams.deploymentId = $Name
+$additionalParams.Set_Item('licenseXml', $licenseFileContent)
+$additionalParams.Set_Item('deploymentId', $Name);
 
 # Inject Certificate Blob and Password into the parameters
 if ($certificateBlob) {


### PR DESCRIPTION
This is just returning back the "lost" fix https://github.com/Sitecore/Sitecore-Azure-Quickstart-Templates/commit/c38771457933ddac71586c2eb71ec8610d0eca89 that was done by Dmitry.
LicenseXML was also incorrectly added to the parameters, so template could not be validated.