### PR TITLE
Disable parallel deployments of modules (fixes Bad Request: Conflict)

### DIFF
--- a/Sitecore 8.2.3/xdb/azuredeploy.json
+++ b/Sitecore 8.2.3/xdb/azuredeploy.json
@@ -532,7 +532,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.3/xm/azuredeploy.json
+++ b/Sitecore 8.2.3/xm/azuredeploy.json
@@ -441,7 +441,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.3/xp/azuredeploy.json
+++ b/Sitecore 8.2.3/xp/azuredeploy.json
@@ -670,7 +670,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.3/xp0/azuredeploy.json
+++ b/Sitecore 8.2.3/xp0/azuredeploy.json
@@ -445,7 +445,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.4/xdb/azuredeploy.json
+++ b/Sitecore 8.2.4/xdb/azuredeploy.json
@@ -532,7 +532,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.4/xm/azuredeploy.json
+++ b/Sitecore 8.2.4/xm/azuredeploy.json
@@ -441,7 +441,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.4/xp/azuredeploy.json
+++ b/Sitecore 8.2.4/xp/azuredeploy.json
@@ -670,7 +670,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.4/xp0/azuredeploy.json
+++ b/Sitecore 8.2.4/xp0/azuredeploy.json
@@ -445,7 +445,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.5/xdb/azuredeploy.json
+++ b/Sitecore 8.2.5/xdb/azuredeploy.json
@@ -532,7 +532,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.5/xm/azuredeploy.json
+++ b/Sitecore 8.2.5/xm/azuredeploy.json
@@ -451,7 +451,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.5/xp/azuredeploy.json
+++ b/Sitecore 8.2.5/xp/azuredeploy.json
@@ -680,7 +680,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 8.2.5/xp0/azuredeploy.json
+++ b/Sitecore 8.2.5/xp0/azuredeploy.json
@@ -454,7 +454,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 9.0.0/XDB/azuredeploy.json
+++ b/Sitecore 9.0.0/XDB/azuredeploy.json
@@ -985,7 +985,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-', parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 9.0.0/XDBSingle/azuredeploy.json
+++ b/Sitecore 9.0.0/XDBSingle/azuredeploy.json
@@ -814,7 +814,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-', parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 9.0.0/XM/azuredeploy.json
+++ b/Sitecore 9.0.0/XM/azuredeploy.json
@@ -419,7 +419,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 9.0.0/XMSingle/azuredeploy.json
+++ b/Sitecore 9.0.0/XMSingle/azuredeploy.json
@@ -442,7 +442,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-' , parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",

--- a/Sitecore 9.0.0/XP/azuredeploy.json
+++ b/Sitecore 9.0.0/XP/azuredeploy.json
@@ -1104,7 +1104,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-', parameters('modules').items[copyIndex()].name)]",
       "condition": "[parameters('deployPlatform')]",

--- a/Sitecore 9.0.0/XPSingle/azuredeploy.json
+++ b/Sitecore 9.0.0/XPSingle/azuredeploy.json
@@ -851,7 +851,9 @@
     {
       "copy": {
         "name": "modules",
-        "count": "[length(parameters('modules').items)]"
+        "count": "[length(parameters('modules').items)]",
+        "mode": "serial",
+        "batchSize": 1
       },
       "name": "[concat(deployment().name, '-', parameters('modules').items[copyIndex()].name)]",
       "apiVersion": "[variables('resourcesApiVersion')]",


### PR DESCRIPTION
Deploying sxa and the bootloader on azure using the modules are handled in parallel by default (see https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-multiple section Serial Copy).

When deploying MSDeploy packages concurrent a Bad Request: Conflict is thrown during the deployment.

This patch prevents concurrent deployments of the modules.