### PR TITLE
EXM XP0: Pass through database and webapp name from main ARM template

### DIFF
--- a/EXM 3.5.0/xp0/azuredeploy.json
+++ b/EXM 3.5.0/xp0/azuredeploy.json
@@ -54,6 +54,18 @@
       "type": "string",
       "defaultValue": "[coalesce(parameters('standardExpanded').deploymentId, resourceGroup().name)]"
     },
+    "singleWebAppName": {
+      "type": "string",
+      "defaultValue": "[parameters('standardExpanded').singleWebAppName]"
+    },
+    "coreSqlDatabaseName": {
+      "type": "string",
+      "defaultValue" : "[parameters('standardExpanded').coreSqlDatabaseName]"
+    },
+    "masterSqlDatabaseName": {
+      "type": "string",
+      "defaultValue" : "[parameters('standardExpanded').masterSqlDatabaseName]"
+    },
     "location": {
       "type": "string",
       "defaultValue": "[coalesce(parameters('standardExpanded').location, resourceGroup().location)]"
@@ -222,6 +234,15 @@
           },
           "location": {
             "value": "[parameters('location')]"
+          },
+          "singleWebAppName": {
+            "value": "[parameters('singleWebAppName')]"
+          },
+          "coreSqlDatabaseName": {
+            "value": "[parameters('coreSqlDatabaseName')]"
+          },
+          "masterSqlDatabaseName": {
+            "value": "[parameters('masterSqlDatabaseName')]"
           },
           "passwordSalt": {
             "value": "[parameters('passwordSalt')]"


### PR DESCRIPTION
The database names of core and master, together with the webapp name are assumed with the default naming conventions instead of listening to the standard parameters that are set in the module loop of the main sitecore installation ARM templates