### PR TITLE
Specifiy MinLength for "messagingSqlDatabaseUserName" as integer 

### DIFF
--- a/Sitecore 9.0.1/XP/azuredeploy.json
+++ b/Sitecore 9.0.1/XP/azuredeploy.json
@@ -274,7 +274,7 @@
     },
     "messagingSqlDatabaseUserName": {
       "type": "string",
-      "minLength": "1",
+      "minLength": 1,
       "defaultValue": "messaginguser"
     },
     "messagingSqlDatabasePassword": {


### PR DESCRIPTION
Please make messagingSqlDatabaseUserName as integer to make it consistent with other values