### PR TITLE
Check whether parameters are in nested porperties object

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ $additionalParams = New-Object -TypeName Hashtable
 
 $params = Get-Content $ArmParametersPath -Raw | ConvertFrom-Json
 
+if ($params.parameters -ne $null) {
+    $params = $params.parameters
+}
+
 foreach($p in $params | Get-Member -MemberType *Property)
 {
     $additionalParams.Add($p.Name, $params.$($p.Name).value)


### PR DESCRIPTION
Without this check, that example PS script cannot read parameters from parameters.json file. I think this fix had already been added but it was removed due some reason (or overwritten) 