### PR TITLE
Fix duplication of 'cm' variable where 'cd' is necessary.

### DIFF
--- a/SXA Storefront 1.0/azuredeploy.json
+++ b/SXA Storefront 1.0/azuredeploy.json
@@ -75,7 +75,7 @@
     "cdWebAppName": {
       "type": "string",
       "minLength": 1,
-      "defaultValue": "[coalesce(parameters('standard').cdWebAppName, concat(parameters('deploymentId'), '-cm'))]"
+      "defaultValue": "[coalesce(parameters('standard').cdWebAppName, concat(parameters('deploymentId'), '-cd'))]"
     },
     "sxaMsDeployPackageUrl": {
       "type": "securestring",


### PR DESCRIPTION
A typo in the SXA Storefront template means the resource declaration for CM is declared twice, resulting in an error from the ARM template engine and potentially the wrong packages being deployed to CM.