### PR TITLE
Add missing EXM parameters XP deployments in Sitecore 9.0.1+

### DIFF
--- a/Sitecore 9.0.1/XP/azuredeploy.json
+++ b/Sitecore 9.0.1/XP/azuredeploy.json
@@ -1356,7 +1356,24 @@
           "applicationInsightsName": {
             "value": "[parameters('applicationInsightsName')]"
           },
-
+          "exmMasterSqlDatabaseName": {
+            "value": "[parameters('exmMasterSqlDatabaseName')]"
+          },
+          "exmMasterSqlDatabaseUserName": {
+            "value": "[parameters('exmMasterSqlDatabaseUserName')]"
+          },
+          "exmMasterSqlDatabasePassword": {
+            "value": "[parameters('exmMasterSqlDatabasePassword')]"
+          },
+          "messagingSqlDatabaseName" : {
+            "value" : "[parameters('messagingSqlDatabaseName')]"
+          },
+          "messagingSqlDatabaseUserName": {
+            "value": "[parameters('messagingSqlDatabaseUserName')]"
+          },
+          "messagingSqlDatabasePassword": {
+            "value": "[parameters('messagingSqlDatabasePassword')]"
+          },
           "cmWebAppName": {
             "value": "[parameters('cmWebAppName')]"
           },

--- a/Sitecore 9.0.2/XP/azuredeploy.json
+++ b/Sitecore 9.0.2/XP/azuredeploy.json
@@ -1405,7 +1405,24 @@
           "applicationInsightsName": {
             "value": "[parameters('applicationInsightsName')]"
           },
-
+          "exmMasterSqlDatabaseName": {
+            "value": "[parameters('exmMasterSqlDatabaseName')]"
+          },
+          "exmMasterSqlDatabaseUserName": {
+            "value": "[parameters('exmMasterSqlDatabaseUserName')]"
+          },
+          "exmMasterSqlDatabasePassword": {
+            "value": "[parameters('exmMasterSqlDatabasePassword')]"
+          },
+          "messagingSqlDatabaseName" : {
+            "value" : "[parameters('messagingSqlDatabaseName')]"
+          },
+          "messagingSqlDatabaseUserName": {
+            "value": "[parameters('messagingSqlDatabaseUserName')]"
+          },
+          "messagingSqlDatabasePassword": {
+            "value": "[parameters('messagingSqlDatabasePassword')]"
+          },
           "cmWebAppName": {
             "value": "[parameters('cmWebAppName')]"
           },


### PR DESCRIPTION
The parameters of the EXM DDS and Messaging database are not passed through to the EXM application ARM causing issues with the connection string when a non-default naming is used.