### PR TITLE
solrConnectionString and templateLinkAccessToken from null to ""

### DIFF
--- a/SXA 1.7.1/xp/azuredeploy.json
+++ b/SXA 1.7.1/xp/azuredeploy.json
@@ -28,7 +28,7 @@
 
         "cdWebAppName": null,
         "cmWebAppName": null,
-        "solrConnectionString": null
+        "solrConnectionString": ""
       }
     },
     "extension": {
@@ -38,7 +38,7 @@
         "cmSxaMsDeployPackageUrl": null,
         "speMsDeployPackageUrl": null,
         "solrSupportSxaMsDeployPackageUrl": null,
-        "templateLinkAccessToken" : null
+        "templateLinkAccessToken" : ""
       }
     },
 


### PR DESCRIPTION
We use the combination of Azure DevOps, Sitecore Quickstart ARM Templates and custom powershell scripts to automate the Sitecore PaaS provisioning. 

I've been trying to use use Sitecore-Azure-Quickstart-Templates to install SXA on a (vanilla) Sitecore 9.0.2 XP env in Azure. The solution is fully PaaS using Azure search. But I kept running into the error:

> A parameter cannot be found that matches parameter name ‘templateLinkAccessToken’.

If I pass an empty string for the templateLinkAccessToken variable, I then get this error:

> A parameter cannot be found that matches parameter name ‘solrConnectionString’.

I asked the the question on Sitecore Slack and had a few responses but didn't have much joy.

I've referenced other templates (Sitecore Commerce 9.0.2 and XP 9.0.2) and found the values for solrConnectionString and templateLinkAccessToken were set to "" and not null. I tried for a couple of days to pass a null/empty value into these variables via Azure DevOps and kept running into some form of the above mentioned errors.

So to make the SXA template consistent with the Commerce and XP 9.0.2 templates, I finally decided to fork the template and change the values in the template itself from null to "" and was able to successfully initialize a ARM deployment in first go (only passing in the parameters as per the Readme.)

This is why I'm submitting this Pull request for your review and a possible merge into the master branch so It's available to every other user.