### PR TITLE
Use the same location for Application Insights

### DIFF
--- a/Sitecore 9.1.0/XP/azuredeploy.json
+++ b/Sitecore 9.1.0/XP/azuredeploy.json
@@ -388,7 +388,7 @@
     },
     "applicationInsightsLocation": {
       "type": "string",
-      "defaultValue": "East US"
+      "defaultValue": "[parameters('location')]"
     },
     "storeSitecoreCountersInApplicationInsights": {
       "type": "bool",

--- a/Sitecore 9.1.0/XPSingle/azuredeploy.json
+++ b/Sitecore 9.1.0/XPSingle/azuredeploy.json
@@ -387,7 +387,7 @@
     },
     "applicationInsightsLocation": {
       "type": "string",
-      "defaultValue": "East US"
+      "defaultValue": "[parameters('location')]"
     },
     "storeSitecoreCountersInApplicationInsights": {
       "type": "bool",


### PR DESCRIPTION
We have policies requiring us to use a specific data-center. If the one setting it up says a data center should be used it should also apply to the Application Insights. (I had to spend some time figuring out why it did not work without this change.)