### PR TITLE
Disabled ARR affinity for web apps

### DIFF
--- a/DEF 2.1.0/Tenant Service/nested/infrastructure-ts.json
+++ b/DEF 2.1.0/Tenant Service/nested/infrastructure-ts.json
@@ -85,6 +85,7 @@
       "name": "[variables('tsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('tsHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/EXM 3.5.0/xp/nested/infrastructure.json
+++ b/EXM 3.5.0/xp/nested/infrastructure.json
@@ -125,6 +125,7 @@
       "name": "[variables('ddsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('ddsHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.1/xdb/azuredeploy.json
+++ b/Sitecore 8.2.1/xdb/azuredeploy.json
@@ -516,6 +516,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -613,6 +614,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.1/xm/azuredeploy.json
+++ b/Sitecore 8.2.1/xm/azuredeploy.json
@@ -479,6 +479,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -558,6 +559,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.1/xp/azuredeploy.json
+++ b/Sitecore 8.2.1/xp/azuredeploy.json
@@ -725,6 +725,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -819,6 +820,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -906,6 +908,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -1004,6 +1007,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.1/xp0/azuredeploy.json
+++ b/Sitecore 8.2.1/xp0/azuredeploy.json
@@ -232,6 +232,7 @@
       "name": "[variables('webAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.3/xdb/nested/infrastructure.json
+++ b/Sitecore 8.2.3/xdb/nested/infrastructure.json
@@ -384,6 +384,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -407,6 +408,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.3/xm/nested/infrastructure.json
+++ b/Sitecore 8.2.3/xm/nested/infrastructure.json
@@ -378,6 +378,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -402,6 +403,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.3/xp/nested/infrastructure.json
+++ b/Sitecore 8.2.3/xp/nested/infrastructure.json
@@ -501,6 +501,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -524,6 +525,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -547,6 +549,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -570,6 +573,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.3/xp0/nested/infrastructure.json
+++ b/Sitecore 8.2.3/xp0/nested/infrastructure.json
@@ -161,6 +161,7 @@
       "name": "[variables('webAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.4/xdb/nested/infrastructure.json
+++ b/Sitecore 8.2.4/xdb/nested/infrastructure.json
@@ -384,6 +384,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -407,6 +408,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.4/xm/nested/infrastructure.json
+++ b/Sitecore 8.2.4/xm/nested/infrastructure.json
@@ -378,6 +378,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -402,6 +403,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.4/xp/nested/infrastructure.json
+++ b/Sitecore 8.2.4/xp/nested/infrastructure.json
@@ -501,6 +501,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -524,6 +525,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -547,6 +549,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -570,6 +573,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.4/xp0/nested/infrastructure.json
+++ b/Sitecore 8.2.4/xp0/nested/infrastructure.json
@@ -161,6 +161,7 @@
       "name": "[variables('webAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.5/xdb/nested/infrastructure.json
+++ b/Sitecore 8.2.5/xdb/nested/infrastructure.json
@@ -380,6 +380,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -403,6 +404,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.5/xm/nested/infrastructure.json
+++ b/Sitecore 8.2.5/xm/nested/infrastructure.json
@@ -375,6 +375,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -399,6 +400,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.5/xp/nested/infrastructure.json
+++ b/Sitecore 8.2.5/xp/nested/infrastructure.json
@@ -497,6 +497,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -520,6 +521,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -543,6 +545,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -566,6 +569,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.5/xp0/nested/infrastructure.json
+++ b/Sitecore 8.2.5/xp0/nested/infrastructure.json
@@ -161,6 +161,7 @@
       "name": "[variables('webAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.7/xdb/nested/infrastructure.json
+++ b/Sitecore 8.2.7/xdb/nested/infrastructure.json
@@ -400,6 +400,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -423,6 +424,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.7/xm/nested/infrastructure.json
+++ b/Sitecore 8.2.7/xm/nested/infrastructure.json
@@ -395,6 +395,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -419,6 +420,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.7/xp/nested/infrastructure.json
+++ b/Sitecore 8.2.7/xp/nested/infrastructure.json
@@ -517,6 +517,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -540,6 +541,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -563,6 +565,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -586,6 +589,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 8.2.7/xp0/nested/infrastructure.json
+++ b/Sitecore 8.2.7/xp0/nested/infrastructure.json
@@ -188,6 +188,7 @@
       "name": "[variables('webAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.0/XDB/nested/infrastructure-ma.json
+++ b/Sitecore 9.0.0/XDB/nested/infrastructure-ma.json
@@ -157,6 +157,7 @@
       "apiVersion": "[variables('webApiVersion')]",
       "location": "[parameters('location')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -178,6 +179,7 @@
       "name": "[variables('maOpsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.0/XDB/nested/infrastructure-xconnect.json
+++ b/Sitecore 9.0.0/XDB/nested/infrastructure-xconnect.json
@@ -310,6 +310,7 @@
       "name": "[variables('xcRefDataWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -364,6 +365,7 @@
       "name": "[variables('xcCollectWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -476,6 +478,7 @@
       "name": "[variables('xcSearchWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.0/XDB/nested/infrastructure.json
+++ b/Sitecore 9.0.0/XDB/nested/infrastructure.json
@@ -476,6 +476,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -500,6 +501,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.0/XDBSingle/nested/infrastructure-xconnect.json
+++ b/Sitecore 9.0.0/XDBSingle/nested/infrastructure-xconnect.json
@@ -135,6 +135,7 @@
       "name": "[variables('xcSingleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcSingleHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.0/XDBSingle/nested/infrastructure.json
+++ b/Sitecore 9.0.0/XDBSingle/nested/infrastructure.json
@@ -226,6 +226,7 @@
       "name": "[variables('singleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.0/XM/nested/infrastructure.json
+++ b/Sitecore 9.0.0/XM/nested/infrastructure.json
@@ -418,6 +418,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -443,6 +444,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.0/XMSingle/nested/infrastructure.json
+++ b/Sitecore 9.0.0/XMSingle/nested/infrastructure.json
@@ -195,6 +195,7 @@
       "name": "[variables('singleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.0/XP/nested/infrastructure-ma.json
+++ b/Sitecore 9.0.0/XP/nested/infrastructure-ma.json
@@ -156,6 +156,7 @@
       "apiVersion": "[variables('webApiVersion')]",
       "location": "[parameters('location')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -177,6 +178,7 @@
       "name": "[variables('maOpsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.0/XP/nested/infrastructure-xconnect.json
+++ b/Sitecore 9.0.0/XP/nested/infrastructure-xconnect.json
@@ -310,6 +310,7 @@
       "name": "[variables('xcRefDataWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -364,6 +365,7 @@
       "name": "[variables('xcCollectWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -476,6 +478,7 @@
       "name": "[variables('xcSearchWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.0/XP/nested/infrastructure.json
+++ b/Sitecore 9.0.0/XP/nested/infrastructure.json
@@ -640,6 +640,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -664,6 +665,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -688,6 +690,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -712,6 +715,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.0/XPSingle/nested/infrastructure-xconnect.json
+++ b/Sitecore 9.0.0/XPSingle/nested/infrastructure-xconnect.json
@@ -135,6 +135,7 @@
       "name": "[variables('xcSingleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcSingleHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.0/XPSingle/nested/infrastructure.json
+++ b/Sitecore 9.0.0/XPSingle/nested/infrastructure.json
@@ -232,6 +232,7 @@
       "name": "[variables('singleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.1/XDB/nested/infrastructure-ma.json
+++ b/Sitecore 9.0.1/XDB/nested/infrastructure-ma.json
@@ -157,6 +157,7 @@
       "apiVersion": "[variables('webApiVersion')]",
       "location": "[parameters('location')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -178,6 +179,7 @@
       "name": "[variables('maOpsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.1/XDB/nested/infrastructure-xconnect.json
+++ b/Sitecore 9.0.1/XDB/nested/infrastructure-xconnect.json
@@ -342,6 +342,7 @@
       "name": "[variables('xcRefDataWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -396,6 +397,7 @@
       "name": "[variables('xcCollectWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -508,6 +510,7 @@
       "name": "[variables('xcSearchWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.1/XDB/nested/infrastructure.json
+++ b/Sitecore 9.0.1/XDB/nested/infrastructure.json
@@ -481,6 +481,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -505,6 +506,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.1/XDBSingle/nested/infrastructure-xconnect.json
+++ b/Sitecore 9.0.1/XDBSingle/nested/infrastructure-xconnect.json
@@ -142,6 +142,7 @@
       "name": "[variables('xcSingleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcSingleHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.1/XDBSingle/nested/infrastructure.json
+++ b/Sitecore 9.0.1/XDBSingle/nested/infrastructure.json
@@ -231,6 +231,7 @@
       "name": "[variables('singleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.1/XM/nested/infrastructure.json
+++ b/Sitecore 9.0.1/XM/nested/infrastructure.json
@@ -423,6 +423,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -448,6 +449,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.1/XMSingle/nested/infrastructure.json
+++ b/Sitecore 9.0.1/XMSingle/nested/infrastructure.json
@@ -200,6 +200,7 @@
       "name": "[variables('singleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.1/XP/nested/infrastructure-exm.json
+++ b/Sitecore 9.0.1/XP/nested/infrastructure-exm.json
@@ -101,6 +101,7 @@
       "name": "[variables('exmDdsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('exmDdsHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.1/XP/nested/infrastructure-ma.json
+++ b/Sitecore 9.0.1/XP/nested/infrastructure-ma.json
@@ -156,6 +156,7 @@
       "apiVersion": "[variables('webApiVersion')]",
       "location": "[parameters('location')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -177,6 +178,7 @@
       "name": "[variables('maOpsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.1/XP/nested/infrastructure-xconnect.json
+++ b/Sitecore 9.0.1/XP/nested/infrastructure-xconnect.json
@@ -342,6 +342,7 @@
       "name": "[variables('xcRefDataWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -396,6 +397,7 @@
       "name": "[variables('xcCollectWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -537,6 +539,7 @@
       "name": "[variables('xcSearchWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.1/XP/nested/infrastructure.json
+++ b/Sitecore 9.0.1/XP/nested/infrastructure.json
@@ -676,6 +676,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -700,6 +701,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -724,6 +726,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -748,6 +751,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.1/XPSingle/nested/infrastructure-xconnect.json
+++ b/Sitecore 9.0.1/XPSingle/nested/infrastructure-xconnect.json
@@ -142,6 +142,7 @@
       "name": "[variables('xcSingleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcSingleHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.1/XPSingle/nested/infrastructure.json
+++ b/Sitecore 9.0.1/XPSingle/nested/infrastructure.json
@@ -243,6 +243,7 @@
       "name": "[variables('singleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.2/XDB/nested/infrastructure-ma.json
+++ b/Sitecore 9.0.2/XDB/nested/infrastructure-ma.json
@@ -157,6 +157,7 @@
       "apiVersion": "[variables('webApiVersion')]",
       "location": "[parameters('location')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -178,6 +179,7 @@
       "name": "[variables('maOpsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.2/XDB/nested/infrastructure-xc.json
+++ b/Sitecore 9.0.2/XDB/nested/infrastructure-xc.json
@@ -342,6 +342,7 @@
       "name": "[variables('xcRefDataWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -396,6 +397,7 @@
       "name": "[variables('xcCollectWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -508,6 +510,7 @@
       "name": "[variables('xcSearchWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.2/XDB/nested/infrastructure.json
+++ b/Sitecore 9.0.2/XDB/nested/infrastructure.json
@@ -493,6 +493,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -517,6 +518,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.2/XDBSingle/nested/infrastructure-xc.json
+++ b/Sitecore 9.0.2/XDBSingle/nested/infrastructure-xc.json
@@ -142,6 +142,7 @@
       "name": "[variables('xcSingleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcSingleHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.2/XDBSingle/nested/infrastructure.json
+++ b/Sitecore 9.0.2/XDBSingle/nested/infrastructure.json
@@ -233,6 +233,7 @@
       "name": "[variables('singleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.2/XM/nested/infrastructure.json
+++ b/Sitecore 9.0.2/XM/nested/infrastructure.json
@@ -436,6 +436,7 @@
       "location": "[parameters('location')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -460,6 +461,7 @@
       "location": "[parameters('location')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.2/XMSingle/nested/infrastructure.json
+++ b/Sitecore 9.0.2/XMSingle/nested/infrastructure.json
@@ -203,6 +203,7 @@
       "location": "[parameters('location')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.2/XP/nested/infrastructure-exm.json
+++ b/Sitecore 9.0.2/XP/nested/infrastructure-exm.json
@@ -101,6 +101,7 @@
       "name": "[variables('exmDdsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('exmDdsHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.2/XP/nested/infrastructure-ma.json
+++ b/Sitecore 9.0.2/XP/nested/infrastructure-ma.json
@@ -156,6 +156,7 @@
       "apiVersion": "[variables('webApiVersion')]",
       "location": "[parameters('location')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -177,6 +178,7 @@
       "name": "[variables('maOpsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.2/XP/nested/infrastructure-xc.json
+++ b/Sitecore 9.0.2/XP/nested/infrastructure-xc.json
@@ -342,6 +342,7 @@
       "name": "[variables('xcRefDataWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -396,6 +397,7 @@
       "name": "[variables('xcCollectWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -537,6 +539,7 @@
       "name": "[variables('xcSearchWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.2/XP/nested/infrastructure.json
+++ b/Sitecore 9.0.2/XP/nested/infrastructure.json
@@ -689,6 +689,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -713,6 +714,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -737,6 +739,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -761,6 +764,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.0.2/XPSingle/nested/infrastructure-xc.json
+++ b/Sitecore 9.0.2/XPSingle/nested/infrastructure-xc.json
@@ -142,6 +142,7 @@
       "name": "[variables('xcSingleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcSingleHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.0.2/XPSingle/nested/infrastructure.json
+++ b/Sitecore 9.0.2/XPSingle/nested/infrastructure.json
@@ -246,6 +246,7 @@
       "name": "[variables('singleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.1.0/XDB/nested/infrastructure-cortex-prc-rep.json
+++ b/Sitecore 9.1.0/XDB/nested/infrastructure-cortex-prc-rep.json
@@ -283,6 +283,7 @@
       "name": "[variables('cortexProcessingWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -305,6 +306,7 @@
       "name": "[variables('cortexReportingWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.1.0/XDB/nested/infrastructure-ma.json
+++ b/Sitecore 9.1.0/XDB/nested/infrastructure-ma.json
@@ -157,6 +157,7 @@
       "apiVersion": "[variables('webApiVersion')]",
       "location": "[parameters('location')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -178,6 +179,7 @@
       "name": "[variables('maOpsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.1.0/XDB/nested/infrastructure-xc.json
+++ b/Sitecore 9.1.0/XDB/nested/infrastructure-xc.json
@@ -342,6 +342,7 @@
       "name": "[variables('xcRefDataWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.1.0/XDB/nested/infrastructure.json
+++ b/Sitecore 9.1.0/XDB/nested/infrastructure.json
@@ -429,6 +429,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -453,6 +454,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.1.0/XDBSingle/nested/infrastructure-xc.json
+++ b/Sitecore 9.1.0/XDBSingle/nested/infrastructure-xc.json
@@ -163,6 +163,7 @@
       "name": "[variables('xcSingleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcSingleHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.1.0/XDBSingle/nested/infrastructure.json
+++ b/Sitecore 9.1.0/XDBSingle/nested/infrastructure.json
@@ -224,6 +224,7 @@
       "name": "[variables('singleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.1.0/XM/nested/infrastructure.json
+++ b/Sitecore 9.1.0/XM/nested/infrastructure.json
@@ -503,6 +503,7 @@
       "location": "[parameters('location')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('siHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -540,6 +541,7 @@
       "location": "[parameters('location')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.1.0/XMSingle/nested/infrastructure.json
+++ b/Sitecore 9.1.0/XMSingle/nested/infrastructure.json
@@ -246,6 +246,7 @@
       "location": "[parameters('location')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -287,6 +288,7 @@
       "location": "[parameters('location')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('siHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.1.0/XP/nested/infrastructure-cortex-prc-rep.json
+++ b/Sitecore 9.1.0/XP/nested/infrastructure-cortex-prc-rep.json
@@ -283,6 +283,7 @@
       "name": "[variables('cortexProcessingWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -305,6 +306,7 @@
       "name": "[variables('cortexReportingWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.1.0/XP/nested/infrastructure-exm.json
+++ b/Sitecore 9.1.0/XP/nested/infrastructure-exm.json
@@ -101,6 +101,7 @@
       "name": "[variables('exmDdsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('exmDdsHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.1.0/XP/nested/infrastructure-ma.json
+++ b/Sitecore 9.1.0/XP/nested/infrastructure-ma.json
@@ -156,6 +156,7 @@
       "apiVersion": "[variables('webApiVersion')]",
       "location": "[parameters('location')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -177,6 +178,7 @@
       "name": "[variables('maOpsWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.1.0/XP/nested/infrastructure-xc.json
+++ b/Sitecore 9.1.0/XP/nested/infrastructure-xc.json
@@ -342,6 +342,7 @@
       "name": "[variables('xcRefDataWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -396,6 +397,7 @@
       "name": "[variables('xcCollectWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcResourceIntensiveHostingPlanNameTidy'))]",
         "siteConfig": {
@@ -537,6 +539,7 @@
       "name": "[variables('xcSearchWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "clientCertEnabled": true,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcBasicHostingPlanNameTidy'))]",
         "siteConfig": {

--- a/Sitecore 9.1.0/XP/nested/infrastructure.json
+++ b/Sitecore 9.1.0/XP/nested/infrastructure.json
@@ -710,6 +710,7 @@
       "location": "[parameters('location')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('siHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -746,6 +747,7 @@
       "name": "[variables('cmWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -770,6 +772,7 @@
       "name": "[variables('cdWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -794,6 +797,7 @@
       "name": "[variables('prcWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('prcHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -818,6 +822,7 @@
       "name": "[variables('repWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('repHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.1.0/XPSingle/nested/infrastructure-xc.json
+++ b/Sitecore 9.1.0/XPSingle/nested/infrastructure-xc.json
@@ -164,6 +164,7 @@
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
         "clientCertEnabled": true,
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('xcSingleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore 9.1.0/XPSingle/nested/infrastructure.json
+++ b/Sitecore 9.1.0/XPSingle/nested/infrastructure.json
@@ -283,6 +283,7 @@
       "location": "[parameters('location')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('siHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -319,6 +320,7 @@
       "name": "[variables('singleWebAppNameTidy')]",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,

--- a/Sitecore XC 9.0.0/nested/infrastructure.json
+++ b/Sitecore XC 9.0.0/nested/infrastructure.json
@@ -369,6 +369,7 @@
       },
       "properties": {
         "name": "[variables('shopsWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('engineHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -388,6 +389,7 @@
       },
       "properties": {
         "name": "[variables('opsWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('engineHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -407,6 +409,7 @@
       },
       "properties": {
         "name": "[variables('authoringWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('engineHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -443,6 +446,7 @@
       },
       "properties": {
         "name": "[variables('minionsWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('minionsHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -462,6 +466,7 @@
       },
       "properties": {
         "name": "[variables('idserverAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -481,6 +486,7 @@
       },
       "properties": {
         "name": "[variables('bizfxAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false

--- a/Sitecore XC 9.0.2/nested/infrastructure.json
+++ b/Sitecore XC 9.0.2/nested/infrastructure.json
@@ -606,6 +606,7 @@
       },
       "properties": {
         "name": "[variables('shopsWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('engineHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -625,6 +626,7 @@
       },
       "properties": {
         "name": "[variables('opsWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('engineHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -644,6 +646,7 @@
       },
       "properties": {
         "name": "[variables('authoringWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('engineHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -680,6 +683,7 @@
       },
       "properties": {
         "name": "[variables('minionsWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('minionsHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -700,6 +704,7 @@
       },
       "properties": {
         "name": "[variables('idserverAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -719,6 +724,7 @@
       },
       "properties": {
         "name": "[variables('bizfxAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false

--- a/Sitecore XC 9.0.3/nested/infrastructure.json
+++ b/Sitecore XC 9.0.3/nested/infrastructure.json
@@ -606,6 +606,7 @@
       },
       "properties": {
         "name": "[variables('shopsWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('engineHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -625,6 +626,7 @@
       },
       "properties": {
         "name": "[variables('opsWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('engineHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -644,6 +646,7 @@
       },
       "properties": {
         "name": "[variables('authoringWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('engineHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -680,6 +683,7 @@
       },
       "properties": {
         "name": "[variables('minionsWebAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('minionsHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false,
@@ -700,6 +704,7 @@
       },
       "properties": {
         "name": "[variables('idserverAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false
@@ -719,6 +724,7 @@
       },
       "properties": {
         "name": "[variables('bizfxAppNameTidy')]",
+        "clientAffinityEnabled": false,
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]",
         "siteConfig": {
           "use32BitWorkerProcess": false


### PR DESCRIPTION
Since Sitecore in PaaS uses Redis for session state, ARR affinity should be disabled by default to improve performance.