### PR TITLE
Set "Security Connection String" parameter to security DB

### DIFF
--- a/Sitecore 9.2.0/XM/nested/application.json
+++ b/Sitecore 9.2.0/XM/nested/application.json
@@ -247,7 +247,7 @@
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
                 "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
                 "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
                 "CertificateStoreLocation": "CurrentUser",
                 "PasswordRecoveryUrl": "[concat('https://', parameters('cmWebAppHostName'))]",

--- a/Sitecore 9.2.0/XMSingle/nested/application.json
+++ b/Sitecore 9.2.0/XMSingle/nested/application.json
@@ -228,7 +228,7 @@
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
                 "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
                 "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
                 "CertificateStoreLocation": "CurrentUser",
                 "PasswordRecoveryUrl": "[concat('https://', parameters('singleWebAppHostName'))]",

--- a/Sitecore 9.2.0/XP/nested/application.json
+++ b/Sitecore 9.2.0/XP/nested/application.json
@@ -468,7 +468,7 @@
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
                 "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
                 "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
                 "CertificateStoreLocation": "CurrentUser",
                 "PasswordRecoveryUrl": "[concat('https://', parameters('cmWebAppHostName'))]",

--- a/Sitecore 9.2.0/XPSingle/nested/application.json
+++ b/Sitecore 9.2.0/XPSingle/nested/application.json
@@ -347,7 +347,7 @@
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
                 "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
                 "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
                 "CertificateStoreLocation": "CurrentUser",
                 "PasswordRecoveryUrl": "[concat('https://', parameters('singleWebAppHostName'))]",

--- a/Sitecore 9.3.0/XM/nested/application.json
+++ b/Sitecore 9.3.0/XM/nested/application.json
@@ -247,7 +247,7 @@
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
                 "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
                 "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
                 "CertificateStoreLocation": "CurrentUser",
                 "PasswordRecoveryUrl": "[concat('https://', parameters('cmWebAppHostName'))]",

--- a/Sitecore 9.3.0/XMSingle/nested/application.json
+++ b/Sitecore 9.3.0/XMSingle/nested/application.json
@@ -228,7 +228,7 @@
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
                 "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
                 "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
                 "CertificateStoreLocation": "CurrentUser",
                 "PasswordRecoveryUrl": "[concat('https://', parameters('singleWebAppHostName'))]",

--- a/Sitecore 9.3.0/XP/nested/application.json
+++ b/Sitecore 9.3.0/XP/nested/application.json
@@ -468,7 +468,7 @@
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
                 "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
                 "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
                 "CertificateStoreLocation": "CurrentUser",
                 "PasswordRecoveryUrl": "[concat('https://', parameters('cmWebAppHostName'))]",

--- a/Sitecore 9.3.0/XPSingle/nested/application.json
+++ b/Sitecore 9.3.0/XPSingle/nested/application.json
@@ -347,7 +347,7 @@
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
                 "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
                 "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
                 "CertificateStoreLocation": "CurrentUser",
                 "PasswordRecoveryUrl": "[concat('https://', parameters('singleWebAppHostName'))]",


### PR DESCRIPTION
Sets the "Security Connection String" parameter to use the security database variables when deploying the SI web app.