### PR TITLE
Fix intermittent dependency problem during deployment of cortex-proce…

### DIFF
--- a/Sitecore 9.1.1/XDB/nested/application-cortex-prc-rep.json
+++ b/Sitecore 9.1.1/XDB/nested/application-cortex-prc-rep.json
@@ -290,7 +290,7 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/config', variables('cortexProcessingWebAppNameTidy'), 'appsettings')]"
+        "[resourceId('Microsoft.Web/sites/config', variables('cortexReportingWebAppNameTidy'), 'appsettings')]"
       ]
     },
     {
@@ -303,7 +303,7 @@
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexReportingWebAppNameTidy'), 'MSDeploy')]"
+        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexProcessingWebAppNameTidy'), 'MSDeploy')]"
       ]
     }
   ]

--- a/Sitecore 9.1.1/XP/nested/application-cortex-prc-rep.json
+++ b/Sitecore 9.1.1/XP/nested/application-cortex-prc-rep.json
@@ -290,7 +290,7 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/config', variables('cortexProcessingWebAppNameTidy'), 'appsettings')]"
+        "[resourceId('Microsoft.Web/sites/config', variables('cortexReportingWebAppNameTidy'), 'appsettings')]"
       ]
     },
     {
@@ -303,7 +303,7 @@
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexReportingWebAppNameTidy'), 'MSDeploy')]"
+        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexProcessingWebAppNameTidy'), 'MSDeploy')]"
       ]
     }
   ]

--- a/Sitecore 9.2.0/XDB/nested/application-cortex-prc-rep.json
+++ b/Sitecore 9.2.0/XDB/nested/application-cortex-prc-rep.json
@@ -281,7 +281,7 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/config', variables('cortexProcessingWebAppNameTidy'), 'appsettings')]"
+        "[resourceId('Microsoft.Web/sites/config', variables('cortexReportingWebAppNameTidy'), 'appsettings')]"
       ]
     },
     {
@@ -294,7 +294,7 @@
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexReportingWebAppNameTidy'), 'MSDeploy')]"
+        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexProcessingWebAppNameTidy'), 'MSDeploy')]"
       ]
     }
   ]

--- a/Sitecore 9.2.0/XP/nested/application-cortex-prc-rep.json
+++ b/Sitecore 9.2.0/XP/nested/application-cortex-prc-rep.json
@@ -281,7 +281,7 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/config', variables('cortexProcessingWebAppNameTidy'), 'appsettings')]"
+        "[resourceId('Microsoft.Web/sites/config', variables('cortexReportingWebAppNameTidy'), 'appsettings')]"
       ]
     },
     {
@@ -294,7 +294,7 @@
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexReportingWebAppNameTidy'), 'MSDeploy')]"
+        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexProcessingWebAppNameTidy'), 'MSDeploy')]"
       ]
     }
   ]

--- a/Sitecore 9.3.0/XDB/nested/application-cortex-prc-rep.json
+++ b/Sitecore 9.3.0/XDB/nested/application-cortex-prc-rep.json
@@ -288,7 +288,7 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/config', variables('cortexProcessingWebAppNameTidy'), 'appsettings')]"
+        "[resourceId('Microsoft.Web/sites/config', variables('cortexReportingWebAppNameTidy'), 'appsettings')]"
       ]
     },
     {
@@ -301,7 +301,7 @@
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexReportingWebAppNameTidy'), 'MSDeploy')]"
+        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexProcessingWebAppNameTidy'), 'MSDeploy')]"
       ]
     }
   ]

--- a/Sitecore 9.3.0/XP/nested/application-cortex-prc-rep.json
+++ b/Sitecore 9.3.0/XP/nested/application-cortex-prc-rep.json
@@ -288,7 +288,7 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/config', variables('cortexProcessingWebAppNameTidy'), 'appsettings')]"
+        "[resourceId('Microsoft.Web/sites/config', variables('cortexReportingWebAppNameTidy'), 'appsettings')]"
       ]
     },
     {
@@ -301,7 +301,7 @@
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexReportingWebAppNameTidy'), 'MSDeploy')]"
+        "[resourceId('Microsoft.Web/sites/extensions', variables('cortexProcessingWebAppNameTidy'), 'MSDeploy')]"
       ]
     }
   ]


### PR DESCRIPTION
Fix intermittent dependency problem during deployment of cortex-processing-webapp-msdeploy for Sitecore 9.1.1 - Sitecore 9.3.0 (XDB and XP)

Changed the dependency on 
"name": "[concat(variables('cortexProcessingWebAppNameTidy'), '/', 'MSDeploy')]",

to
"[resourceId('Microsoft.Web/sites/config', variables('cortexReportingWebAppNameTidy'), 'appsettings')]"

also changed the dependency on 
"name": "[concat(variables('cortexProcessingWebAppNameTidy'), '/', 'appsettings')]",

to
"[resourceId('Microsoft.Web/sites/extensions', variables('cortexProcessingWebAppNameTidy'), 'MSDeploy')]"

With this change we avoid intermittent Conflict errors (Race conditions) during the deployment of the /MsDeploy task because of a potential app pool recycle due to the /appsettings being deployed. 

Updated the following files
Sitecore 9.1.1/XDB/nested/application-cortex-prc-rep.json
Sitecore 9.1.1/XP/nested/application-cortex-prc-rep.json
Sitecore 9.2.0/XDB/nested/application-cortex-prc-rep.json
Sitecore 9.2.0/XP/nested/application-cortex-prc-rep.json
Sitecore 9.3.0/XDB/nested/application-cortex-prc-rep.json
Sitecore 9.3.0/XP/nested/application-cortex-prc-rep.json