### PR TITLE
Add xcSearchWebAppName param

### DIFF
--- a/Sitecore 9.3.0/XP/nested/application-xc.json
+++ b/Sitecore 9.3.0/XP/nested/application-xc.json
@@ -561,7 +561,12 @@
           },
           "xpPerformanceCountersType": {
             "value": "[parameters('xpPerformanceCountersType')]"
+          },
+
+          "xcSearchWebAppName": {
+            "value": "[parameters('xcSearchWebAppName')]"
           }
+      
         }
       },
       "dependsOn": [


### PR DESCRIPTION
Parameter added into the “-application-xc-search-solr” deployment as the SOLR template tries to find the webapp with the default name only. This enables support for custom naming of webapp