### PR TITLE
update 5xx alert setting & reallocate properties

### DIFF
--- a/Monitoring 10.0.0/xdb/azuredeploy.json
+++ b/Monitoring 10.0.0/xdb/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "10.0.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 10.0.0/xdb/nested/alertwebsites.json
+++ b/Monitoring 10.0.0/xdb/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 10.0.0/xm/azuredeploy.json
+++ b/Monitoring 10.0.0/xm/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "10.0.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 10.0.0/xm/nested/alertwebsites.json
+++ b/Monitoring 10.0.0/xm/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 10.0.0/xp/azuredeploy.json
+++ b/Monitoring 10.0.0/xp/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "10.0.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 10.0.0/xp/nested/alertwebsites.json
+++ b/Monitoring 10.0.0/xp/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -422,13 +422,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -462,13 +462,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -502,13 +502,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.1/xdb/azuredeploy.json
+++ b/Monitoring 8.2.1/xdb/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.1",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 8.2.1/xdb/nested/alertwebsites.json
+++ b/Monitoring 8.2.1/xdb/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.1/xm/azuredeploy.json
+++ b/Monitoring 8.2.1/xm/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.1",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 8.2.1/xm/nested/alertwebsites.json
+++ b/Monitoring 8.2.1/xm/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.1/xp/azuredeploy.json
+++ b/Monitoring 8.2.1/xp/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.1",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 8.2.1/xp/nested/alertwebsites.json
+++ b/Monitoring 8.2.1/xp/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.2/xdb/azuredeploy.json
+++ b/Monitoring 8.2.2/xdb/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.2",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 8.2.2/xdb/nested/alertwebsites.json
+++ b/Monitoring 8.2.2/xdb/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.2/xm/azuredeploy.json
+++ b/Monitoring 8.2.2/xm/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.2",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 8.2.2/xm/nested/alertwebsites.json
+++ b/Monitoring 8.2.2/xm/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.2/xp/azuredeploy.json
+++ b/Monitoring 8.2.2/xp/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.2",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 8.2.2/xp/nested/alertwebsites.json
+++ b/Monitoring 8.2.2/xp/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.3/xdb/azuredeploy.json
+++ b/Monitoring 8.2.3/xdb/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.3",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 8.2.3/xdb/nested/alertwebsites.json
+++ b/Monitoring 8.2.3/xdb/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.3/xm/azuredeploy.json
+++ b/Monitoring 8.2.3/xm/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.3",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 8.2.3/xm/nested/alertwebsites.json
+++ b/Monitoring 8.2.3/xm/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.3/xp/azuredeploy.json
+++ b/Monitoring 8.2.3/xp/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.3",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 8.2.3/xp/nested/alertwebsites.json
+++ b/Monitoring 8.2.3/xp/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.4/xdb/azuredeploy.json
+++ b/Monitoring 8.2.4/xdb/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.4",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 8.2.4/xdb/nested/alertwebsites.json
+++ b/Monitoring 8.2.4/xdb/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.4/xm/azuredeploy.json
+++ b/Monitoring 8.2.4/xm/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.4",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 8.2.4/xm/nested/alertwebsites.json
+++ b/Monitoring 8.2.4/xm/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.4/xp/azuredeploy.json
+++ b/Monitoring 8.2.4/xp/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.4",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 8.2.4/xp/nested/alertwebsites.json
+++ b/Monitoring 8.2.4/xp/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.5/xdb/azuredeploy.json
+++ b/Monitoring 8.2.5/xdb/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.5",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 8.2.5/xdb/nested/alertwebsites.json
+++ b/Monitoring 8.2.5/xdb/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.5/xm/azuredeploy.json
+++ b/Monitoring 8.2.5/xm/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.5",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 8.2.5/xm/nested/alertwebsites.json
+++ b/Monitoring 8.2.5/xm/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.5/xp/azuredeploy.json
+++ b/Monitoring 8.2.5/xp/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.5",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 8.2.5/xp/nested/alertwebsites.json
+++ b/Monitoring 8.2.5/xp/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.6/xdb/azuredeploy.json
+++ b/Monitoring 8.2.6/xdb/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.6",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 8.2.6/xdb/nested/alertwebsites.json
+++ b/Monitoring 8.2.6/xdb/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.6/xm/azuredeploy.json
+++ b/Monitoring 8.2.6/xm/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.6",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 8.2.6/xm/nested/alertwebsites.json
+++ b/Monitoring 8.2.6/xm/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.6/xp/azuredeploy.json
+++ b/Monitoring 8.2.6/xp/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.6",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 8.2.6/xp/nested/alertwebsites.json
+++ b/Monitoring 8.2.6/xp/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.7/xdb/azuredeploy.json
+++ b/Monitoring 8.2.7/xdb/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.7",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 8.2.7/xdb/nested/alertwebsites.json
+++ b/Monitoring 8.2.7/xdb/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.7/xm/azuredeploy.json
+++ b/Monitoring 8.2.7/xm/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.7",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 8.2.7/xm/nested/alertwebsites.json
+++ b/Monitoring 8.2.7/xm/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 8.2.7/xp/azuredeploy.json
+++ b/Monitoring 8.2.7/xp/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "8.2.7",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 8.2.7/xp/nested/alertwebsites.json
+++ b/Monitoring 8.2.7/xp/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.0.0/XDB/azuredeploy.json
+++ b/Monitoring 9.0.0/XDB/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.0.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 9.0.0/XDB/nested/alertwebsites.json
+++ b/Monitoring 9.0.0/XDB/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.0.0/XM/azuredeploy.json
+++ b/Monitoring 9.0.0/XM/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.0.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 9.0.0/XM/nested/alertwebsites.json
+++ b/Monitoring 9.0.0/XM/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.0.0/XP/azuredeploy.json
+++ b/Monitoring 9.0.0/XP/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.0.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 9.0.0/XP/nested/alertwebsites.json
+++ b/Monitoring 9.0.0/XP/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.0.1/XDB/azuredeploy.json
+++ b/Monitoring 9.0.1/XDB/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.0.1",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 9.0.1/XDB/nested/alertwebsites.json
+++ b/Monitoring 9.0.1/XDB/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.0.1/XM/azuredeploy.json
+++ b/Monitoring 9.0.1/XM/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.0.1",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 9.0.1/XM/nested/alertwebsites.json
+++ b/Monitoring 9.0.1/XM/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.0.1/XP/azuredeploy.json
+++ b/Monitoring 9.0.1/XP/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -12,16 +22,6 @@
     "searchProvider": {
       "type": "string",
       "defaultValue": "Azure"
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -72,7 +72,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.0.1",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 9.0.1/XP/nested/alertwebsites.json
+++ b/Monitoring 9.0.1/XP/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.0.2/XDB/azuredeploy.json
+++ b/Monitoring 9.0.2/XDB/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.0.2",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 9.0.2/XDB/nested/alertwebsites.json
+++ b/Monitoring 9.0.2/XDB/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.0.2/XM/azuredeploy.json
+++ b/Monitoring 9.0.2/XM/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.0.2",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 9.0.2/XM/nested/alertwebsites.json
+++ b/Monitoring 9.0.2/XM/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.0.2/XP/azuredeploy.json
+++ b/Monitoring 9.0.2/XP/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.0.2",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 9.0.2/XP/nested/alertwebsites.json
+++ b/Monitoring 9.0.2/XP/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.1.0/XDB/azuredeploy.json
+++ b/Monitoring 9.1.0/XDB/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.1.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 9.1.0/XDB/nested/alertwebsites.json
+++ b/Monitoring 9.1.0/XDB/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.1.0/XM/azuredeploy.json
+++ b/Monitoring 9.1.0/XM/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.1.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 9.1.0/XM/nested/alertwebsites.json
+++ b/Monitoring 9.1.0/XM/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.1.0/XP/azuredeploy.json
+++ b/Monitoring 9.1.0/XP/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.1.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 9.1.0/XP/nested/alertwebsites.json
+++ b/Monitoring 9.1.0/XP/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -422,13 +422,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -462,13 +462,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -502,13 +502,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.1.1/XDB/azuredeploy.json
+++ b/Monitoring 9.1.1/XDB/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.1.1",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 9.1.1/XDB/nested/alertwebsites.json
+++ b/Monitoring 9.1.1/XDB/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.1.1/XM/azuredeploy.json
+++ b/Monitoring 9.1.1/XM/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.1.1",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 9.1.1/XM/nested/alertwebsites.json
+++ b/Monitoring 9.1.1/XM/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.1.1/XP/azuredeploy.json
+++ b/Monitoring 9.1.1/XP/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.1.1",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 9.1.1/XP/nested/alertwebsites.json
+++ b/Monitoring 9.1.1/XP/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -422,13 +422,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -462,13 +462,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -502,13 +502,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.2.0/XDB/azuredeploy.json
+++ b/Monitoring 9.2.0/XDB/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.2.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 9.2.0/XDB/nested/alertwebsites.json
+++ b/Monitoring 9.2.0/XDB/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.2.0/XM/azuredeploy.json
+++ b/Monitoring 9.2.0/XM/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.2.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 9.2.0/XM/nested/alertwebsites.json
+++ b/Monitoring 9.2.0/XM/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.2.0/XP/azuredeploy.json
+++ b/Monitoring 9.2.0/XP/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.2.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 9.2.0/XP/nested/alertwebsites.json
+++ b/Monitoring 9.2.0/XP/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -422,13 +422,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -462,13 +462,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -502,13 +502,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.3.0/XDB/azuredeploy.json
+++ b/Monitoring 9.3.0/XDB/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.3.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xdb"

--- a/Monitoring 9.3.0/XDB/nested/alertwebsites.json
+++ b/Monitoring 9.3.0/XDB/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.3.0/XM/azuredeploy.json
+++ b/Monitoring 9.3.0/XM/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.3.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xm"

--- a/Monitoring 9.3.0/XM/nested/alertwebsites.json
+++ b/Monitoring 9.3.0/XM/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"

--- a/Monitoring 9.3.0/XP/azuredeploy.json
+++ b/Monitoring 9.3.0/XP/azuredeploy.json
@@ -2,6 +2,16 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "extension": {
+      "type": "secureObject",
+      "defaultValue": {
+        "omsWorkspaceAlertRecipients": null,
+        "omsWorkspaceMetricsRetentionDays": null,
+        "omsWorkspaceLocation": null,
+        "applicationInsightsLocation": null,
+        "templateLinkAccessToken": ""
+      }
+    },
     "standard": {
       "type": "secureObject",
       "defaultValue": {
@@ -17,16 +27,6 @@
         "Azure",
         "Solr"
       ]
-    },
-    "extension": {
-      "type": "secureObject",
-      "defaultValue": {
-        "omsWorkspaceAlertRecipients": null,
-        "omsWorkspaceMetricsRetentionDays": null,
-        "omsWorkspaceLocation": null,
-        "applicationInsightsLocation": null,
-        "templateLinkAccessToken": ""
-      }
     },
     "deploymentId": {
       "type": "string",
@@ -77,7 +77,7 @@
     "resourcesApiVersion": "2016-09-01",
     "tags": {
       "sc-monitoring": "Yes",
-      "sc-monitoring-pkg-version": "2.3.4-r201119",
+      "sc-monitoring-pkg-version": "2.4.0-r210215",
       "sc-monitoring-sc-version": "9.3.0",
       "sc-monitoring-type": "Basic",
       "sc-monitoring-sc-topology": "xp"

--- a/Monitoring 9.3.0/XP/nested/alertwebsites.json
+++ b/Monitoring 9.3.0/XP/nested/alertwebsites.json
@@ -62,13 +62,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -102,13 +102,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -142,13 +142,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -182,13 +182,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -222,13 +222,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -262,13 +262,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -302,13 +302,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -342,13 +342,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -382,13 +382,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -422,13 +422,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -462,13 +462,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"
@@ -502,13 +502,13 @@
           "queryType": "ResultCount"
         },
         "schedule": {
-          "frequencyInMinutes": "5",
+          "frequencyInMinutes": "15",
           "timeWindowInMinutes": "60"
         },
         "action": {
           "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
           "severity": "1",
-          "throttlingInMin": "0",
+          "throttlingInMin": "479",
           "aznsAction": {
             "actionGroup": [
               "[variables('actionGroupResourceId')]"


### PR DESCRIPTION
@dma-sitecore 

Work item:
Bug [357905](https://dev.azure.com/Sitecore-PD/Products/_sprints/backlog/Cloud%20Automation%20APJ/Products/PI-work/PI25/PI25-Sprint2-Mon?workitem=357905): Alert rule "WebApp returning high rate of 5xx errors" is creating too many alerts

Change summary:
- All topologies have the same change
- Reallocate "extension" to higher position
- Increase 5xx alert evaluation frequency and introduce suppression of 479 minutes
- Update package version