### PR TITLE
Added SI web app and hosting plan to modules parameters

### DIFF
--- a/Sitecore 10.0.0/XM/azuredeploy.json
+++ b/Sitecore 10.0.0/XM/azuredeploy.json
@@ -686,9 +686,11 @@
 
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
+              "siHostingPlanName": "[parameters('siHostingPlanName')]",
 
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "securityClientIp": "[parameters('securityClientIp')]",
               "securityClientIpMask": "[parameters('securityClientIpMask')]",

--- a/Sitecore 10.0.0/XMSingle/azuredeploy.json
+++ b/Sitecore 10.0.0/XMSingle/azuredeploy.json
@@ -674,6 +674,7 @@
 
               "singleHostingPlanName": "[parameters('singleHostingPlanName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",              
 
               "passwordSalt": "[parameters('passwordSalt')]",
 

--- a/Sitecore 10.0.0/XP/azuredeploy.json
+++ b/Sitecore 10.0.0/XP/azuredeploy.json
@@ -2134,6 +2134,7 @@
 
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
+              "siHostingPlanName": "[parameters('siHostingPlanName')]",
               "prcHostingPlanName": "[parameters('prcHostingPlanName')]",
               "repHostingPlanName": "[parameters('repHostingPlanName')]",
               "xcBasicHostingPlanName": "[parameters('xcBasicHostingPlanName')]",
@@ -2141,6 +2142,7 @@
 
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
               "prcWebAppName": "[parameters('prcWebAppName')]",
               "repWebAppName": "[parameters('repWebAppName')]",
               "xcRefDataWebAppName": "[parameters('xcRefDataWebAppName')]",

--- a/Sitecore 10.0.0/XPSingle/azuredeploy.json
+++ b/Sitecore 10.0.0/XPSingle/azuredeploy.json
@@ -1357,6 +1357,7 @@
 
               "xcSingleWebAppName": "[parameters('xcSingleWebAppName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "passwordSalt": "[parameters('passwordSalt')]",
 

--- a/Sitecore 9.1.0/XM/azuredeploy.json
+++ b/Sitecore 9.1.0/XM/azuredeploy.json
@@ -698,9 +698,11 @@
 
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
+              "siHostingPlanName": "[parameters('siHostingPlanName')]",
 
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "securityClientIp": "[parameters('securityClientIp')]",
               "securityClientIpMask": "[parameters('securityClientIpMask')]",

--- a/Sitecore 9.1.0/XMSingle/azuredeploy.json
+++ b/Sitecore 9.1.0/XMSingle/azuredeploy.json
@@ -685,6 +685,7 @@
 
               "singleHostingPlanName": "[parameters('singleHostingPlanName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "passwordSalt": "[parameters('passwordSalt')]"
             }

--- a/Sitecore 9.1.0/XP/azuredeploy.json
+++ b/Sitecore 9.1.0/XP/azuredeploy.json
@@ -2027,6 +2027,7 @@
 
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
+              "siHostingPlanName": "[parameters('siHostingPlanName')]",
               "prcHostingPlanName": "[parameters('prcHostingPlanName')]",
               "repHostingPlanName": "[parameters('repHostingPlanName')]",
               "xcBasicHostingPlanName": "[parameters('xcBasicHostingPlanName')]",
@@ -2034,6 +2035,7 @@
 
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
               "prcWebAppName": "[parameters('prcWebAppName')]",
               "repWebAppName": "[parameters('repWebAppName')]",
               "xcRefDataWebAppName": "[parameters('xcRefDataWebAppName')]",

--- a/Sitecore 9.1.0/XPSingle/azuredeploy.json
+++ b/Sitecore 9.1.0/XPSingle/azuredeploy.json
@@ -1285,6 +1285,7 @@
 
               "xcSingleWebAppName": "[parameters('xcSingleWebAppName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "passwordSalt": "[parameters('passwordSalt')]",
 

--- a/Sitecore 9.1.1/XM/azuredeploy.json
+++ b/Sitecore 9.1.1/XM/azuredeploy.json
@@ -433,8 +433,7 @@
           "siHostingPlanName": {
             "value": "[parameters('siHostingPlanName')]"
           },
-          "cmHostingPlanName": {
-            "value": "[parameters('cmHostingPlanName')]"
+          "cmHostingPlanName": {"value": "[parameters('cmHostingPlanName')]"
           },
           "cdHostingPlanName": {
             "value": "[parameters('cdHostingPlanName')]"
@@ -686,9 +685,11 @@
 
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
+              "siHostingPlanName": "[parameters('siHostingPlanName')]",
 
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "securityClientIp": "[parameters('securityClientIp')]",
               "securityClientIpMask": "[parameters('securityClientIpMask')]",

--- a/Sitecore 9.1.1/XMSingle/azuredeploy.json
+++ b/Sitecore 9.1.1/XMSingle/azuredeploy.json
@@ -674,6 +674,7 @@
 
               "singleHostingPlanName": "[parameters('singleHostingPlanName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "passwordSalt": "[parameters('passwordSalt')]",
 

--- a/Sitecore 9.1.1/XP/azuredeploy.json
+++ b/Sitecore 9.1.1/XP/azuredeploy.json
@@ -2031,6 +2031,7 @@
 
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
+              "siHostingPlanName": "[parameters('siHostingPlanName')]",
               "prcHostingPlanName": "[parameters('prcHostingPlanName')]",
               "repHostingPlanName": "[parameters('repHostingPlanName')]",
               "xcBasicHostingPlanName": "[parameters('xcBasicHostingPlanName')]",
@@ -2038,6 +2039,7 @@
 
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
               "prcWebAppName": "[parameters('prcWebAppName')]",
               "repWebAppName": "[parameters('repWebAppName')]",
               "xcRefDataWebAppName": "[parameters('xcRefDataWebAppName')]",

--- a/Sitecore 9.1.1/XPSingle/azuredeploy.json
+++ b/Sitecore 9.1.1/XPSingle/azuredeploy.json
@@ -1278,6 +1278,7 @@
 
               "xcSingleWebAppName": "[parameters('xcSingleWebAppName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "passwordSalt": "[parameters('passwordSalt')]",
 

--- a/Sitecore 9.2.0/XM/azuredeploy.json
+++ b/Sitecore 9.2.0/XM/azuredeploy.json
@@ -686,9 +686,11 @@
 
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
+              "siHostingPlanName": "[parameters('siHostingPlanName')]",
 
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "securityClientIp": "[parameters('securityClientIp')]",
               "securityClientIpMask": "[parameters('securityClientIpMask')]",

--- a/Sitecore 9.2.0/XMSingle/azuredeploy.json
+++ b/Sitecore 9.2.0/XMSingle/azuredeploy.json
@@ -674,6 +674,7 @@
 
               "singleHostingPlanName": "[parameters('singleHostingPlanName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "passwordSalt": "[parameters('passwordSalt')]",
 

--- a/Sitecore 9.2.0/XP/azuredeploy.json
+++ b/Sitecore 9.2.0/XP/azuredeploy.json
@@ -2108,6 +2108,7 @@
 
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
+              "siHostingPlanName": "[parameters('siHostingPlanName')]",
               "prcHostingPlanName": "[parameters('prcHostingPlanName')]",
               "repHostingPlanName": "[parameters('repHostingPlanName')]",
               "xcBasicHostingPlanName": "[parameters('xcBasicHostingPlanName')]",
@@ -2115,6 +2116,7 @@
 
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
               "prcWebAppName": "[parameters('prcWebAppName')]",
               "repWebAppName": "[parameters('repWebAppName')]",
               "xcRefDataWebAppName": "[parameters('xcRefDataWebAppName')]",

--- a/Sitecore 9.2.0/XPSingle/azuredeploy.json
+++ b/Sitecore 9.2.0/XPSingle/azuredeploy.json
@@ -1349,6 +1349,7 @@
 
               "xcSingleWebAppName": "[parameters('xcSingleWebAppName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "passwordSalt": "[parameters('passwordSalt')]",
 

--- a/Sitecore 9.3.0/XM/azuredeploy.json
+++ b/Sitecore 9.3.0/XM/azuredeploy.json
@@ -686,9 +686,11 @@
 
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
+              "siHostingPlanName": "[parameters('siHostingPlanName')]",
 
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "securityClientIp": "[parameters('securityClientIp')]",
               "securityClientIpMask": "[parameters('securityClientIpMask')]",

--- a/Sitecore 9.3.0/XMSingle/azuredeploy.json
+++ b/Sitecore 9.3.0/XMSingle/azuredeploy.json
@@ -674,6 +674,7 @@
 
               "singleHostingPlanName": "[parameters('singleHostingPlanName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "passwordSalt": "[parameters('passwordSalt')]",
 

--- a/Sitecore 9.3.0/XP/azuredeploy.json
+++ b/Sitecore 9.3.0/XP/azuredeploy.json
@@ -2128,6 +2128,7 @@
 
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
+              "siHostingPlanName": "[parameters('siHostingPlanName')]",
               "prcHostingPlanName": "[parameters('prcHostingPlanName')]",
               "repHostingPlanName": "[parameters('repHostingPlanName')]",
               "xcBasicHostingPlanName": "[parameters('xcBasicHostingPlanName')]",
@@ -2135,6 +2136,7 @@
 
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
               "prcWebAppName": "[parameters('prcWebAppName')]",
               "repWebAppName": "[parameters('repWebAppName')]",
               "xcRefDataWebAppName": "[parameters('xcRefDataWebAppName')]",

--- a/Sitecore 9.3.0/XPSingle/azuredeploy.json
+++ b/Sitecore 9.3.0/XPSingle/azuredeploy.json
@@ -1357,6 +1357,7 @@
 
               "xcSingleWebAppName": "[parameters('xcSingleWebAppName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
+              "siWebAppName": "[parameters('siWebAppName')]",
 
               "passwordSalt": "[parameters('passwordSalt')]",
 


### PR DESCRIPTION
Noticed that SI web app and hosting plan were missing from the modules parameters so I have added them everywhere from v9.1.0+.  
These may be needed when setting custom app settings or scaling up to take advantage of premium features (private endpoint, etc.).  