### PR TITLE
Lowercasing the storage account name to avoid failures

### DIFF
--- a/Azure Blob Storage 1.0.0/XM/azuredeploy.json
+++ b/Azure Blob Storage 1.0.0/XM/azuredeploy.json
@@ -178,7 +178,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 1.0.0/XMSingle/azuredeploy.json
+++ b/Azure Blob Storage 1.0.0/XMSingle/azuredeploy.json
@@ -146,7 +146,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 1.0.0/XP/azuredeploy.json
+++ b/Azure Blob Storage 1.0.0/XP/azuredeploy.json
@@ -193,7 +193,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 1.0.0/XPSingle/azuredeploy.json
+++ b/Azure Blob Storage 1.0.0/XPSingle/azuredeploy.json
@@ -146,7 +146,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 2.0.0/XM/azuredeploy.json
+++ b/Azure Blob Storage 2.0.0/XM/azuredeploy.json
@@ -178,7 +178,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 2.0.0/XMSingle/azuredeploy.json
+++ b/Azure Blob Storage 2.0.0/XMSingle/azuredeploy.json
@@ -146,7 +146,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 2.0.0/XP/azuredeploy.json
+++ b/Azure Blob Storage 2.0.0/XP/azuredeploy.json
@@ -193,7 +193,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 2.0.0/XPSingle/azuredeploy.json
+++ b/Azure Blob Storage 2.0.0/XPSingle/azuredeploy.json
@@ -146,7 +146,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 3.0.0/XM/azuredeploy.json
+++ b/Azure Blob Storage 3.0.0/XM/azuredeploy.json
@@ -178,7 +178,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 3.0.0/XMSingle/azuredeploy.json
+++ b/Azure Blob Storage 3.0.0/XMSingle/azuredeploy.json
@@ -146,7 +146,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 3.0.0/XP/azuredeploy.json
+++ b/Azure Blob Storage 3.0.0/XP/azuredeploy.json
@@ -193,7 +193,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"

--- a/Azure Blob Storage 3.0.0/XPSingle/azuredeploy.json
+++ b/Azure Blob Storage 3.0.0/XPSingle/azuredeploy.json
@@ -146,7 +146,7 @@
                         "value": "[parameters('location')]"
                     },
                     "storageAccountName": {
-                        "value": "[parameters('storageAccountName')]"
+                        "value": "[toLower(parameters('storageAccountName'))]"
                     },
                     "accessTier": {
                         "value": "[parameters('accessTier')]"


### PR DESCRIPTION
Lowercasing the storage account name to avoid failures if the deployment Id, resource group name have capital letters