### PR TITLE
Updated SQL Database hardware from Gen4 to Gen5

### DIFF
--- a/Sitecore XC 9.2.0/XCScaled/nested/infrastructure.json
+++ b/Sitecore XC 9.2.0/XCScaled/nested/infrastructure.json
@@ -365,7 +365,7 @@
           "sharedSqlDatabase": {
             "Edition": "GeneralPurpose",
             "MaxSize": "268435456000",
-            "ServiceObjectiveLevel": "GP_Gen4_2"
+            "ServiceObjectiveLevel": "GP_Gen5_2"
           },
           "redisCache": {
             "SkuName": "Standard",
@@ -417,7 +417,7 @@
           "sharedSqlDatabase": {
             "Edition": "GeneralPurpose",
             "MaxSize": "268435456000",
-            "ServiceObjectiveLevel": "GP_Gen4_3"
+            "ServiceObjectiveLevel": "GP_Gen5_4"
           },
           "redisCache": {
             "SkuName": "Standard",
@@ -469,7 +469,7 @@
           "sharedSqlDatabase": {
             "Edition": "GeneralPurpose",
             "MaxSize": "268435456000",
-            "ServiceObjectiveLevel": "GP_Gen4_4"
+            "ServiceObjectiveLevel": "GP_Gen5_6"
           },
           "redisCache": {
             "SkuName": "Standard",


### PR DESCRIPTION
Modified  XC9.2.0\XCScaled\nested\infrastructure.json to replace end-of-lifed Azure SQL Database Gen 4 hardware with Gen5. This is the only XC release where we specified Gen4 hardware.
For more background, see discussion in PBI 511316: [IR] Clarification on Azure Sitecore Experience Cloud for Commerce