### PR TITLE
Adding master connection string for SPE extension

### DIFF
--- a/SXA 10.3.0/xm/azuredeploy.json
+++ b/SXA 10.3.0/xm/azuredeploy.json
@@ -6,6 +6,7 @@
     "resourcesApiVersion": "2016-09-01",
     "sqlServerFqdnTidy": "[toLower(trim(parameters('sqlServerFqdn')))]",
     "coreSqlDatabaseNameTidy": "[toLower(trim(parameters('coreSqlDatabaseName')))]",
+    "masterSqlDatabaseNameTidy": "[toLower(trim(parameters('masterSqlDatabaseNameTidy')))]",
     "cdWebAppNameTidy": "[toLower(trim(parameters('cdWebAppName')))]",
     "cmWebAppNameTidy": "[toLower(trim(parameters('cmWebAppName')))]"
   },
@@ -113,7 +114,8 @@
             "connectionString": "[concat('Data Source=tcp:', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=master;User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
             "setParameters": {
               "Application Path": "[variables('cmWebAppNameTidy')]",
-              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]"
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
+              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('masterSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]"
             }
           },
           {


### PR DESCRIPTION
Adding master connection string for SPE as it is a required parameter in sitecore webdeploy ffile

We encountered below error while deploying the webdeploy file using the ARM:

Package deployment failed
ARM-MSDeploy Deploy Failed: 'Microsoft.Web.Deployment.DeploymentException: The path '' is not valid for the 'dbDacFx' provider. ---&gt; System.ArgumentNullException: Value cannot be null. Parameter name: value

Changes to fix the above issue are delivered here.