### PR TITLE
Workspace-based Application Insights, TLS 1.2, API versions

### DIFF
--- a/Sitecore 10.1.0/XM/README.md
+++ b/Sitecore 10.1.0/XM/README.md
@@ -4,21 +4,20 @@ Visualize:
 [Infrastructure](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FSitecore%2Fsitecore-azure-quickstart-templates%2Fmaster%2FSitecore%209.0.0%2Fxm%2Fnested%2Finfrastructure.json),
 [Application deployment](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FSitecore%2Fsitecore-azure-quickstart-templates%2Fmaster%2FSitecore%209.0.0%2Fxm%2Fnested%2Fapplication.json)
 
-
 This template creates a Sitecore XM Environment with all resources necessary to run Sitecore.
 
 Resources provisioned:
 
-  * Azure SQL databases : core, master, web, forms
-  * Azure Redis Cache for session state
-  * Sitecore roles: Content Delivery, Content Management
-	  * Hosting plans: one per role
-	  * Preconfigured Web Applications, based on the provided WebDeploy packages
+* Azure SQL databases : core, master, web, forms
+* Azure Redis Cache for session state
+* Sitecore roles: Content Delivery, Content Management
+  * Hosting plans: one per role
+  * Preconfigured Web Applications, based on the provided WebDeploy packages
   * Azure Search Service
-  * (optional) Application Insights for diagnostics and monitoring
-
+* (optional) Application Insights for diagnostics and monitoring
 
 ## Parameters
+
 The **deploymentId** and **licenseXml** parameters are to be filled in by the PowerShell script.
 
 | Parameter               | Description
@@ -37,9 +36,9 @@ The **deploymentId** and **licenseXml** parameters are to be filled in by the Po
 > to specify geographical region to deploy Azure Search Service. Default value is the resource
 > group location.
 > * The **applicationInsightsLocation** parameter can be added to the`azuredeploy.parameters.json`
-> to specify geographical region to deploy Application Insights. Default value is **East US**.
+>   to specify geographical region to deploy Application Insights. Default value is **East US**.
 > * The **useApplicationInsights** parameter can be added to the`azuredeploy.parameters.json`
-> to control whether Application Insights will be used for diagnostics and monitoring. Default value is **true**.
+>   to control whether Application Insights will be used for diagnostics and monitoring. Default value is **true**.
 
 ## Deploying with Solr Search
 
@@ -49,13 +48,14 @@ The **deploymentId** and **licenseXml** parameters are to be filled in by the Po
 --------------------------------------------|------------------------------------------------
 | solrConnectionString                      | Connection string to existing Solr server.
 
-> **solrConnectionString** parameter is used to identify whether Solr search provider is to be used for the deployment or not. 
+> **solrConnectionString** parameter is used to identify whether Solr search provider is to be used for the deployment or not.
 > The default value is empty which means that Azure Search will be used.
 
 ## Deploying with App Service Environment v2
-> **Note**: Application Service Environment is not provisioned as part of this deployment template. Please reffer to official [documentation](https://docs.microsoft.com/en-us/azure/app-service/environment/intro) for information about ASE deployment and configuration. 
+
+> **Note**: Application Service Environment is not provisioned as part of this deployment template. Please refer to official [documentation](https://docs.microsoft.com/en-us/azure/app-service/environment/intro) for information about ASE deployment and configuration.
 
 | Parameter                                 | Description
 --------------------------------------------|------------------------------------------------
 | aseName                                   | Name of deployed App Service Environment
-| aseResourceGroupName                      | Resource group where App Service Environment is deployed. Provide this value if ASE is hosted in different resouce group
+| aseResourceGroupName                      | Resource group where App Service Environment is deployed. Provide this value if ASE is hosted in different resource group

--- a/Sitecore 10.1.0/XM/addons/bootloader.json
+++ b/Sitecore 10.1.0/XM/addons/bootloader.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",

--- a/Sitecore 10.1.0/XM/addons/generic.json
+++ b/Sitecore 10.1.0/XM/addons/generic.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",

--- a/Sitecore 10.1.0/XM/azuredeploy.json
+++ b/Sitecore 10.1.0/XM/azuredeploy.json
@@ -1,5 +1,5 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "resourcesApiVersion": "2018-05-01",
@@ -18,8 +18,7 @@
           {
             "name": "empty",
             "templateLink": "[concat(uri(parameters('templateLinkBase'), 'nested/emptyAddon.json'), parameters('templateLinkAccessToken'))]",
-            "parameters": {
-            }
+            "parameters": {}
           }
         ]
       }
@@ -31,13 +30,11 @@
           {
             "name": "empty-prerequisite",
             "templateLink": "[concat(uri(parameters('templateLinkBase'), 'nested/emptyAddon.json'), parameters('templateLinkAccessToken'))]",
-            "parameters": {
-            }
+            "parameters": {}
           }
         ]
       }
     },
-
     "templateLinkBase": {
       "type": "string",
       "defaultValue": "[uri(replace(json(string(deployment().properties.templateLink)).uri,' ','%20'), '.')]"
@@ -46,7 +43,6 @@
       "type": "securestring",
       "defaultValue": ""
     },
-
     "deploymentId": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
@@ -55,7 +51,6 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]"
     },
-
     "sitecoreAdminPassword": {
       "type": "securestring",
       "minLength": 8
@@ -66,13 +61,20 @@
     },
     "sitecoreSKU": {
       "type": "string",
-      "allowedValues": [ "Extra Small", "Small", "Medium", "Large", "Extra Large", "2x Large", "3x Large" ],
+      "allowedValues": [
+        "Extra Small",
+        "Small",
+        "Medium",
+        "Large",
+        "Extra Large",
+        "2x Large",
+        "3x Large"
+      ],
       "defaultValue": "Extra Small",
       "metadata": {
         "description": "Sitecore SKU controls the sizes and service levels of the provisioned resources"
       }
     },
-
     "sqlServerName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-sql')]"
@@ -85,7 +87,6 @@
       "type": "securestring",
       "minLength": 8
     },
-
     "sqlServerVersion": {
       "type": "string",
       "defaultValue": "12.0"
@@ -94,7 +95,6 @@
       "type": "string",
       "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
     },
-
     "coreSqlDatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-core-db')]"
@@ -115,7 +115,6 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-forms-db')]"
     },
-
     "coreSqlDatabaseUserName": {
       "type": "string",
       "minLength": 1,
@@ -166,7 +165,6 @@
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('forms', parameters('passwordSalt'))), uniqueString('forms', parameters('sqlServerPassword'), parameters('passwordSalt')), toUpper(uniqueString('forms', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '4@')]"
     },
-
     "redisCacheName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-redis')]"
@@ -189,7 +187,6 @@
       "type": "securestring",
       "defaultValue": ""
     },
-
     "useApplicationInsights": {
       "type": "bool",
       "defaultValue": true
@@ -211,7 +208,6 @@
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-ai-pp')]"
     },
-
     "siHostingPlanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-si-hp')]"
@@ -224,7 +220,6 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cd-hp')]"
     },
-
     "siWebAppName": {
       "type": "string",
       "minLength": 1,
@@ -238,7 +233,6 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cd')]"
     },
-
     "siMsDeployPackageUrl": {
       "type": "securestring",
       "minLength": 1
@@ -259,7 +253,6 @@
       "type": "string",
       "defaultValue": "0.0.0.0"
     },
-
     "authCertificateName": {
       "type": "string",
       "minLength": 1,
@@ -273,45 +266,48 @@
       "type": "securestring",
       "minLength": 1
     },
-
     "siClientSecret": {
       "type": "securestring",
       "minLength": 6,
       "defaultValue": "[toUpper(replace(guid(uniqueString('siClientSecret', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '-',''))]"
     },
-
     "telerikEncryptionKey": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('telerik', parameters('passwordSalt'))), uniqueString('telerik', parameters('sqlServerPassword'), parameters('passwordSalt')), toUpper(uniqueString('telerik', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '4@')]"
     },
-
     "passwordSalt": {
       "type": "securestring",
       "minLength": 1,
       "defaultValue": "[resourceGroup().id]"
     },
-
-    "aseName":{
+    "aseName": {
       "type": "string",
       "defaultValue": ""
     },
-    "aseResourceGroupName":{
+    "aseResourceGroupName": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
     },
-    "cmNodeJsVersion":{
+    "cmNodeJsVersion": {
       "type": "string",
       "defaultValue": "8.11.1"
     },
-    "cdNodeJsVersion":{
+    "cdNodeJsVersion": {
       "type": "string",
       "defaultValue": "8.11.1"
     },
-    
     "environmentType": {
       "type": "string",
       "defaultValue": "Non-Production"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
+    },
+    "omsWorkspaceName": {
+      "type": "string",
+      "defaultValue": "[concat(toLower(parameters('deploymentId')), '-oms')]"
     }
   },
   "resources": [
@@ -343,7 +339,6 @@
           "uri": "[concat(uri(parameters('templateLinkBase'), 'nested/infrastructure.json'), parameters('templateLinkAccessToken'))]"
         },
         "parameters": {
-
           "deploymentId": {
             "value": "[parameters('deploymentId')]"
           },
@@ -353,7 +348,6 @@
           "sitecoreSKU": {
             "value": "[parameters('sitecoreSKU')]"
           },
-
           "sqlServerName": {
             "value": "[parameters('sqlServerName')]"
           },
@@ -363,14 +357,12 @@
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "sqlServerVersion": {
             "value": "[parameters('sqlServerVersion')]"
           },
           "sqlDatabaseCollation": {
             "value": "[parameters('sqlDatabaseCollation')]"
           },
-
           "coreSqlDatabaseName": {
             "value": "[parameters('coreSqlDatabaseName')]"
           },
@@ -383,7 +375,6 @@
           "formsSqlDatabaseName": {
             "value": "[parameters('formsSqlDatabaseName')]"
           },
-
           "authCertificateName": {
             "value": "[parameters('authCertificateName')]"
           },
@@ -411,7 +402,6 @@
           "redisCacheName": {
             "value": "[parameters('redisCacheName')]"
           },
-
           "useApplicationInsights": {
             "value": "[parameters('useApplicationInsights')]"
           },
@@ -424,7 +414,9 @@
           "applicationInsightsPricePlan": {
             "value": "[parameters('applicationInsightsPricePlan')]"
           },
-
+          "omsWorkspaceName": {
+            "value": "[parameters('omsWorkspaceName')]"
+          },
           "siHostingPlanName": {
             "value": "[parameters('siHostingPlanName')]"
           },
@@ -434,7 +426,6 @@
           "cdHostingPlanName": {
             "value": "[parameters('cdHostingPlanName')]"
           },
-
           "siWebAppName": {
             "value": "[parameters('siWebAppName')]"
           },
@@ -447,8 +438,11 @@
           "aseName": {
             "value": "[parameters('aseName')]"
           },
-          "aseResourceGroupName":{
+          "aseResourceGroupName": {
             "value": "[parameters('aseResourceGroupName')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -466,32 +460,27 @@
           "uri": "[concat(uri(parameters('templateLinkBase'), 'nested/application.json'), parameters('templateLinkAccessToken'))]"
         },
         "parameters": {
-
           "infrastructure": {
             "value": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]"
           },
-
           "deploymentId": {
             "value": "[parameters('deploymentId')]"
           },
           "location": {
             "value": "[parameters('location')]"
           },
-
           "sitecoreAdminPassword": {
             "value": "[parameters('sitecoreAdminPassword')]"
           },
           "licenseXml": {
             "value": "[parameters('licenseXml')]"
           },
-
           "sqlServerLogin": {
             "value": "[parameters('sqlServerLogin')]"
           },
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "coreSqlDatabaseName": {
             "value": "[parameters('coreSqlDatabaseName')]"
           },
@@ -507,7 +496,6 @@
           "formsSqlDatabaseName": {
             "value": "[parameters('formsSqlDatabaseName')]"
           },
-
           "coreSqlDatabaseUserName": {
             "value": "[parameters('coreSqlDatabaseUserName')]"
           },
@@ -546,11 +534,9 @@
           "solrConnectionString": {
             "value": "[parameters('solrConnectionString')]"
           },
-
           "redisCacheName": {
             "value": "[parameters('redisCacheName')]"
           },
-
           "useApplicationInsights": {
             "value": "[parameters('useApplicationInsights')]"
           },
@@ -560,7 +546,6 @@
           "storeSitecoreCountersInApplicationInsights": {
             "value": "[parameters('storeSitecoreCountersInApplicationInsights')]"
           },
-
           "siWebAppName": {
             "value": "[parameters('siWebAppName')]"
           },
@@ -570,7 +555,6 @@
           "cdWebAppName": {
             "value": "[parameters('cdWebAppName')]"
           },
-
           "siMsDeployPackageUrl": {
             "value": "[parameters('siMsDeployPackageUrl')]"
           },
@@ -586,28 +570,26 @@
           "securityClientIpMask": {
             "value": "[parameters('securityClientIpMask')]"
           },
-
           "siClientSecret": {
             "value": "[parameters('siClientSecret')]"
           },
           "telerikEncryptionKey": {
             "value": "[parameters('telerikEncryptionKey')]"
           },
-
           "passwordSalt": {
             "value": "[parameters('passwordSalt')]"
           },
-
           "cmNodeJsVersion": {
             "value": "[parameters('cmNodeJsVersion')]"
           },
-
           "cdNodeJsVersion": {
             "value": "[parameters('cdNodeJsVersion')]"
           },
-
           "environmentType": {
             "value": "[parameters('environmentType')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -631,28 +613,21 @@
         "parameters": {
           "standard": {
             "value": {
-
               "infrastructure": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]",
-
               "deploymentId": "[parameters('deploymentId')]",
               "location": "[parameters('location')]",
-
               "sitecoreAdminPassword": "[parameters('sitecoreAdminPassword')]",
               "licenseXml": "[parameters('licenseXml')]",
               "sitecoreSKU": "[parameters('sitecoreSKU')]",
-
               "sqlServerName": "[parameters('sqlServerName')]",
               "sqlServerLogin": "[parameters('sqlServerLogin')]",
               "sqlServerPassword": "[parameters('sqlServerPassword')]",
-
               "sqlServerVersion": "[parameters('sqlServerVersion')]",
               "sqlDatabaseCollation": "[parameters('sqlDatabaseCollation')]",
-
               "coreSqlDatabaseName": "[parameters('coreSqlDatabaseName')]",
               "masterSqlDatabaseName": "[parameters('masterSqlDatabaseName')]",
               "webSqlDatabaseName": "[parameters('webSqlDatabaseName')]",
               "formsSqlDatabaseName": "[parameters('formsSqlDatabaseName')]",
-
               "coreSqlDatabaseUserName": "[parameters('coreSqlDatabaseUserName')]",
               "coreSqlDatabasePassword": "[parameters('coreSqlDatabasePassword')]",
               "masterSqlDatabaseUserName": "[parameters('masterSqlDatabaseUserName')]",
@@ -668,29 +643,24 @@
               "searchServiceLocation": "[parameters('searchServiceLocation')]",
 
               "solrConnectionString": "[parameters('solrConnectionString')]",
-
               "redisCacheName": "[parameters('redisCacheName')]",
-
               "useApplicationInsights": "[parameters('useApplicationInsights')]",
               "applicationInsightsName": "[parameters('applicationInsightsName')]",
               "applicationInsightsLocation": "[parameters('applicationInsightsLocation')]",
               "storeSitecoreCountersInApplicationInsights": "[parameters('storeSitecoreCountersInApplicationInsights')]",
-
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
-
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
-
               "securityClientIp": "[parameters('securityClientIp')]",
               "securityClientIpMask": "[parameters('securityClientIpMask')]",
-
               "passwordSalt": "[parameters('passwordSalt')]",
-
               "environmentType": "[parameters('environmentType')]"
             }
           },
-          "extension": { "value": "[parameters('modules').items[copyIndex()].parameters]" }
+          "extension": {
+            "value": "[parameters('modules').items[copyIndex()].parameters]"
+          }
         }
       },
       "dependsOn": [

--- a/Sitecore 10.1.0/XM/azuredeploy.parameters.json
+++ b/Sitecore 10.1.0/XM/azuredeploy.parameters.json
@@ -1,5 +1,5 @@
-﻿{
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "deploymentId": {
@@ -26,10 +26,10 @@
     "licenseXml": {
       "value": ""
     },
-    "authCertificateBlob":{
+    "authCertificateBlob": {
       "value": ""
     },
-    "authCertificatePassword":{
+    "authCertificatePassword": {
       "value": ""
     }
   }

--- a/Sitecore 10.1.0/XM/nested/application.json
+++ b/Sitecore 10.1.0/XM/nested/application.json
@@ -1,12 +1,12 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "searchApiVersion": "2015-08-19",
     "searchRestApiVersion": "2017-11-11",
-    "redisApiVersion": "2016-04-01",
-    "applicationInsightsApiVersion": "2015-05-01",
+    "redisApiVersion": "2020-06-01",
+    "applicationInsightsApiVersion": "2020-02-02",
     "sqlServerFqdnTidy": "[trim(toLower(parameters('sqlServerFqdn')))]",
     "coreSqlDatabaseNameTidy": "[toLower(trim(parameters('coreSqlDatabaseName')))]",
     "securitySqlDatabaseNameTidy": "[toLower(trim(parameters('securitySqlDatabaseName')))]",
@@ -217,17 +217,21 @@
       "minLength": 1,
       "defaultValue": "[resourceGroup().id]"
     },
-    "cmNodeJsVersion":{
+    "cmNodeJsVersion": {
       "type": "string",
       "defaultValue": "8.11.1"
     },
-    "cdNodeJsVersion":{
+    "cdNodeJsVersion": {
       "type": "string",
       "defaultValue": "8.11.1"
     },
     "environmentType": {
       "type": "string",
       "defaultValue": "Non-Production"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -242,15 +246,15 @@
           {
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
-                "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
-                "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
-                "CertificateStoreLocation": "CurrentUser",
-                "PasswordRecoveryUrl": "[concat('https://', parameters('cmWebAppHostName'))]",
-                "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('applicationInsightsNameTidy')), variables('applicationInsightsApiVersion')).InstrumentationKey, '')]",
-                "License Xml": "[parameters('licenseXml')]",
-                "AllowedCorsOrigins": "[concat('https://', parameters('cmWebAppHostName'))]",
-                "ClientSecret": "[parameters('siClientSecret')]"
+              "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
+              "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+              "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
+              "CertificateStoreLocation": "CurrentUser",
+              "PasswordRecoveryUrl": "[concat('https://', parameters('cmWebAppHostName'))]",
+              "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('applicationInsightsNameTidy')), variables('applicationInsightsApiVersion')).InstrumentationKey, '')]",
+              "License Xml": "[parameters('licenseXml')]",
+              "AllowedCorsOrigins": "[concat('https://', parameters('cmWebAppHostName'))]",
+              "ClientSecret": "[parameters('siClientSecret')]"
             }
           }
         ]
@@ -264,6 +268,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
@@ -364,8 +369,9 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
-        "WEBSITE_NODE_DEFAULT_VERSION":"[parameters('cmNodeJsVersion')]",
+        "WEBSITE_NODE_DEFAULT_VERSION": "[parameters('cmNodeJsVersion')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [
@@ -377,8 +383,9 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
-        "WEBSITE_NODE_DEFAULT_VERSION":"[parameters('cdNodeJsVersion')]",
+        "WEBSITE_NODE_DEFAULT_VERSION": "[parameters('cdNodeJsVersion')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [

--- a/Sitecore 10.1.0/XM/nested/emptyAddon.json
+++ b/Sitecore 10.1.0/XM/nested/emptyAddon.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "standard": {

--- a/Sitecore 10.1.0/XM/nested/infrastructure.json
+++ b/Sitecore 10.1.0/XM/nested/infrastructure.json
@@ -1,17 +1,16 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "serverFarmApiVersion": "2018-02-01",
-    "dbApiVersion": "2014-04-01-preview",
+    "dbApiVersion": "2022-05-01-preview",
     "searchApiVersion": "2015-08-19",
-    "redisApiVersion": "2016-04-01",
-    "applicationInsightsApiVersion": "2015-05-01",
+    "redisApiVersion": "2020-06-01",
+    "applicationInsightsApiVersion": "2020-02-02",
     "certificateApiVersion": "2014-11-01",
-
+    "omsWorkspaceApiVersion": "2017-03-15-preview",
     "sqlServerNameTidy": "[toLower(trim(parameters('sqlServerName')))]",
-
     "coreSqlDatabaseNameTidy": "[toLower(trim(parameters('coreSqlDatabaseName')))]",
     "webSqlDatabaseNameTidy": "[toLower(trim(parameters('webSqlDatabaseName')))]",
     "masterSqlDatabaseNameTidy": "[toLower(trim(parameters('masterSqlDatabaseName')))]",
@@ -19,43 +18,40 @@
 
     "searchServiceNameTidy": "[toLower(trim(parameters('searchServiceName')))]",
     "redisCacheNameTidy": "[toLower(trim(parameters('redisCacheName')))]",
-
     "applicationInsightsNameTidy": "[toLower(trim(parameters('applicationInsightsName')))]",
     "applicationInsightsPricePlanTidy": "[toLower(trim(parameters('applicationInsightsPricePlan')))]",
-
+    "omsWorkspaceNameTidy": "[toLower(trim(parameters('omsWorkspaceName')))]",
     "siHostingPlanNameTidy": "[toLower(trim(parameters('siHostingPlanName')))]",
     "cmHostingPlanNameTidy": "[toLower(trim(parameters('cmHostingPlanName')))]",
     "cdHostingPlanNameTidy": "[toLower(trim(parameters('cdHostingPlanName')))]",
-
     "siWebAppNameTidy": "[toLower(trim(parameters('siWebAppName')))]",
     "cmWebAppNameTidy": "[toLower(trim(parameters('cmWebAppName')))]",
     "cdWebAppNameTidy": "[toLower(trim(parameters('cdWebAppName')))]",
-
     "useAse": "[not(empty(parameters('aseName')))]",
     "aseResourceId": "[resourceId(parameters('aseResourceGroupName'), 'Microsoft.Web/hostingEnvironments', parameters('aseName'))]",
-    "hostingPlanProperties":{
-      "siProperties":{
+    "hostingPlanProperties": {
+      "siProperties": {
         "name": "[variables('siHostingPlanNameTidy')]"
       },
-      "siPropertiesWithASE":{
+      "siPropertiesWithASE": {
         "name": "[variables('siHostingPlanNameTidy')]",
         "hostingEnvironmentProfile": {
           "id": "[variables('aseResourceId')]"
         }
       },
-      "cmProperties":{
+      "cmProperties": {
         "name": "[variables('cmHostingPlanNameTidy')]"
       },
-      "cmPropertiesWithASE":{
+      "cmPropertiesWithASE": {
         "name": "[variables('cmHostingPlanNameTidy')]",
         "hostingEnvironmentProfile": {
           "id": "[variables('aseResourceId')]"
         }
       },
-      "cdProperties":{
+      "cdProperties": {
         "name": "[variables('cdHostingPlanNameTidy')]"
       },
-      "cdPropertiesWithASE":{
+      "cdPropertiesWithASE": {
         "name": "[variables('cdHostingPlanNameTidy')]",
         "hostingEnvironmentProfile": {
           "id": "[variables('aseResourceId')]"
@@ -65,9 +61,7 @@
         "id": "[variables('aseResourceId')]"
       }
     },
-
     "authCertificateNameTidy": "[toLower(trim(parameters('authCertificateName')))]",
-
     "sitecoreTags": {
       "provider": "b51535c2-ab3e-4a68-95f8-e2e3c9a19299",
       "si": "si",
@@ -80,7 +74,6 @@
     }
   },
   "parameters": {
-
     "deploymentId": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
@@ -91,13 +84,20 @@
     },
     "sitecoreSKU": {
       "type": "string",
-      "allowedValues": [ "Extra Small", "Small", "Medium", "Large", "Extra Large", "2x Large", "3x Large" ],
+      "allowedValues": [
+        "Extra Small",
+        "Small",
+        "Medium",
+        "Large",
+        "Extra Large",
+        "2x Large",
+        "3x Large"
+      ],
       "defaultValue": "Extra Small",
       "metadata": {
         "description": "Sitecore SKU controls the sizes and service levels of the provisioned resources"
       }
     },
-
     "sqlServerName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-sql')]"
@@ -110,7 +110,6 @@
       "type": "securestring",
       "minLength": 8
     },
-
     "sqlServerVersion": {
       "type": "string",
       "defaultValue": "12.0"
@@ -119,7 +118,6 @@
       "type": "string",
       "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
     },
-
     "coreSqlDatabaseName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-core-db')]"
@@ -154,12 +152,11 @@
       "type": "int",
       "defaultValue": 1
     },
-    
+
     "redisCacheName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-redis')]"
     },
-
     "useApplicationInsights": {
       "type": "bool",
       "defaultValue": true
@@ -177,7 +174,6 @@
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-ai-pp')]"
     },
-
     "authCertificateName": {
       "type": "string",
       "minLength": 1,
@@ -191,7 +187,6 @@
       "type": "securestring",
       "minLength": 1
     },
-
     "siHostingPlanName": {
       "type": "string",
       "minLength": 1,
@@ -205,7 +200,6 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-cd-hp')]"
     },
-
     "siWebAppName": {
       "type": "string",
       "minLength": 1,
@@ -249,22 +243,22 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "searchService": {
@@ -281,6 +275,13 @@
             "CurrentBillingFeatures": "Basic",
             "DataVolumeCap": {
               "Cap": 0.33
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 1
             }
           }
         },
@@ -311,22 +312,22 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "searchService": {
@@ -343,6 +344,13 @@
             "CurrentBillingFeatures": "Basic",
             "DataVolumeCap": {
               "Cap": 0.33
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 1
             }
           }
         },
@@ -373,22 +381,22 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "searchService": {
@@ -405,6 +413,13 @@
             "CurrentBillingFeatures": "Basic",
             "DataVolumeCap": {
               "Cap": 0.33
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 1
             }
           }
         },
@@ -435,22 +450,22 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "searchService": {
@@ -467,6 +482,13 @@
             "CurrentBillingFeatures": "Basic",
             "DataVolumeCap": {
               "Cap": 0.33
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 1
             }
           }
         },
@@ -497,22 +519,22 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "searchService": {
@@ -529,6 +551,13 @@
             "CurrentBillingFeatures": "Application Insights Enterprise",
             "DataVolumeCap": {
               "Cap": 1.8
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 2
             }
           }
         },
@@ -559,22 +588,22 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S3"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "searchService": {
@@ -591,6 +620,13 @@
             "CurrentBillingFeatures": "Application Insights Enterprise",
             "DataVolumeCap": {
               "Cap": 1.8
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 2
             }
           }
         },
@@ -621,22 +657,22 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S4"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "searchService": {
@@ -654,6 +690,13 @@
             "DataVolumeCap": {
               "Cap": 1.8
             }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 2
+            }
           }
         }
       }
@@ -662,13 +705,21 @@
       "type": "object",
       "defaultValue": "[parameters('skuMap')[parameters('sitecoreSKU')]]"
     },
-    "aseName":{
+    "aseName": {
       "type": "string",
       "defaultValue": ""
     },
-    "aseResourceGroupName":{
+    "aseResourceGroupName": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
+    },
+    "omsWorkspaceName": {
+      "type": "string",
+      "defaultValue": "[concat(parameters('deploymentId'), '-oms')]"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -701,8 +752,8 @@
         "provider": "[variables('sitecoreTags').provider]",
         "logicalName": "[variables('sitecoreTags').cm]"
       },
-      "dependsOn": [ 
-        "[resourceId('Microsoft.Web/serverfarms', variables('siHostingPlanNameTidy'))]" 
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('siHostingPlanNameTidy'))]"
       ]
     },
     {
@@ -719,8 +770,8 @@
         "provider": "[variables('sitecoreTags').provider]",
         "logicalName": "[variables('sitecoreTags').cd]"
       },
-      "dependsOn": [ 
-        "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]" 
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]"
       ]
     },
     {
@@ -807,7 +858,8 @@
       "properties": {
         "administratorLogin": "[parameters('sqlServerLogin')]",
         "administratorLoginPassword": "[parameters('sqlServerPassword')]",
-        "version": "[parameters('sqlServerVersion')]"
+        "version": "[parameters('sqlServerVersion')]",
+        "minimalTlsVersion": "[parameters('minTlsVersion')]"
       },
       "name": "[variables('sqlServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -823,16 +875,20 @@
             "startIpAddress": "0.0.0.0"
           },
           "name": "AllowAllAzureIps",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ]
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ]
         },
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').CoreSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').CoreSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').CoreSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').CoreSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').CoreSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').CoreSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -841,15 +897,17 @@
               "dependsOn": [
                 "[variables('coreSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('coreSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').core]"
@@ -858,11 +916,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').masterSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').masterSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').masterSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').masterSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').masterSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').masterSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -871,28 +931,32 @@
               "dependsOn": [
                 "[variables('masterSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('masterSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').master]"
           }
         },
-		    {
+        {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').webSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').webSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').webSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').webSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').webSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').webSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -901,15 +965,17 @@
               "dependsOn": [
                 "[variables('webSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('webSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').web]"
@@ -918,11 +984,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').formsSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').formsSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').formsSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').formsSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').formsSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').formsSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -931,20 +999,22 @@
               "dependsOn": [
                 "[variables('formsSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('formsSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').forms]"
           }
-              }
+        }
       ]
     },
     {
@@ -994,7 +1064,27 @@
           "family": "[parameters('resourceSizes').redisCache.SkuFamily]",
           "capacity": "[parameters('resourceSizes').redisCache.SkuCapacity]"
         },
-        "enableNonSslPort": false
+        "enableNonSslPort": false,
+        "minimumTlsVersion": "[parameters('minTlsVersion')]"
+      },
+      "tags": {
+        "provider": "[variables('sitecoreTags').provider]"
+      }
+    },
+    {
+      "apiVersion": "[variables('omsWorkspaceApiVersion')]",
+      "name": "[variables('omsWorkspaceNameTidy')]",
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "condition": "[parameters('useApplicationInsights')]",
+      "location": "[parameters('applicationInsightsLocation')]",
+      "properties": {
+        "sku": {
+          "name": "[parameters('resourceSizes').operationalInsightsWorkspace.sku]"
+        },
+        "retention": "[parameters('resourceSizes').operationalInsightsWorkspace.metricsRetentionDays]",
+        "workspaceCapping": {
+          "dailyQuotaGb": "[parameters('resourceSizes').operationalInsightsWorkspace.workspaceCapping.dailyQuotaGb]"
+        }
       },
       "tags": {
         "provider": "[variables('sitecoreTags').provider]"
@@ -1008,11 +1098,15 @@
       "location": "[parameters('applicationInsightsLocation')]",
       "properties": {
         "ApplicationId": "[variables('applicationInsightsNameTidy')]",
-        "Application_Type": "web"
+        "Application_Type": "web",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('omsWorkspaceNameTidy'))]"
       },
       "tags": {
         "provider": "[variables('sitecoreTags').provider]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('omsWorkspaceNameTidy'))]"
+      ]
     },
     {
       "type": "Microsoft.Insights/Components/CurrentBillingFeatures",

--- a/Sitecore 10.1.0/XMSingle/README.md
+++ b/Sitecore 10.1.0/XMSingle/README.md
@@ -4,26 +4,25 @@ Visualize:
 [Infrastructure](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FSitecore%2Fsitecore-azure-quickstart-templates%2Fmaster%2FSitecore%209.0.0%2Fxmsingle%2Fnested%2Finfrastructure.json),
 [Application deployment](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FSitecore%2Fsitecore-azure-quickstart-templates%2Fmaster%2FSitecore%209.0.0%2Fxmsingle%2Fnested%2Fapplication.json)
 
-
 This template creates a Sitecore XM Single Environment using a minimal set of Azure resources while still ensuring Sitecore will run. It is best practice to use this configuration for development and testing rather than production environments.
 
 Resources provisioned:
 
-  * Azure SQL databases : core, master, web, forms
-  * Sitecore roles: Content Delivery, Content Management as a single WebApp instance
-	  * Hosting plans: single hosting plan
-	  * Preconfigured Web Application, based on the provided WebDeploy package
+* Azure SQL databases : core, master, web, forms
+* Sitecore roles: Content Delivery, Content Management as a single WebApp instance
+  * Hosting plans: single hosting plan
+  * Preconfigured Web Application, based on the provided WebDeploy package
   * Azure Search Service
-  * (optional) Application Insights for diagnostics and monitoring
+* (optional) Application Insights for diagnostics and monitoring
 
 > **Note:**
 > * The **searchServiceLocation** parameter can be added to the `azuredeploy.parameters.json`
 > to specify geographical region to deploy Azure Search Service. Default value is the resource
 > group location.
 > * The **applicationInsightsLocation** parameter can be added to the`azuredeploy.parameters.json`
-> to specify geographical region to deploy Application Insights. Default value is **East US**.
+>   to specify geographical region to deploy Application Insights. Default value is **East US**.
 > * The **useApplicationInsights** parameter can be added to the`azuredeploy.parameters.json`
-> to control whether Application Insights will be used for diagnostics and monitoring. Default value is **true**.
+>   to control whether Application Insights will be used for diagnostics and monitoring. Default value is **true**.
 
 ## Parameters
 The **deploymentId** and **licenseXml** parameters are filled in by the PowerShell script.

--- a/Sitecore 10.1.0/XMSingle/addons/bootloader.json
+++ b/Sitecore 10.1.0/XMSingle/addons/bootloader.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",

--- a/Sitecore 10.1.0/XMSingle/addons/generic.json
+++ b/Sitecore 10.1.0/XMSingle/addons/generic.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",

--- a/Sitecore 10.1.0/XMSingle/azuredeploy.json
+++ b/Sitecore 10.1.0/XMSingle/azuredeploy.json
@@ -1,5 +1,5 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "resourcesApiVersion": "2018-05-01",
@@ -18,8 +18,7 @@
           {
             "name": "empty",
             "templateLink": "[concat(uri(parameters('templateLinkBase'), 'nested/emptyAddon.json'), parameters('templateLinkAccessToken'))]",
-            "parameters": {
-            }
+            "parameters": {}
           }
         ]
       }
@@ -31,13 +30,11 @@
           {
             "name": "empty-prerequisite",
             "templateLink": "[concat(uri(parameters('templateLinkBase'), 'nested/emptyAddon.json'), parameters('templateLinkAccessToken'))]",
-            "parameters": {
-            }
+            "parameters": {}
           }
         ]
       }
     },
-
     "templateLinkBase": {
       "type": "string",
       "minLength": 1,
@@ -47,7 +44,6 @@
       "type": "securestring",
       "defaultValue": ""
     },
-
     "deploymentId": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
@@ -57,7 +53,6 @@
       "minLength": 1,
       "defaultValue": "[resourceGroup().location]"
     },
-
     "sitecoreAdminPassword": {
       "type": "securestring",
       "minLength": 8
@@ -66,7 +61,6 @@
       "type": "securestring",
       "minLength": 1
     },
-
     "sqlServerName": {
       "type": "string",
       "minLength": 1,
@@ -80,7 +74,6 @@
       "type": "securestring",
       "minLength": 8
     },
-
     "sqlServerVersion": {
       "type": "string",
       "minLength": 1,
@@ -97,9 +90,8 @@
       "defaultValue": "Standard"
     },
     "sqlDatabaseMaxSize": {
-      "type": "string",
-      "minLength": 1,
-      "defaultValue": "268435456000"
+      "type": "int",
+      "defaultValue": 268435456000
     },
     "sqlBasicDatabaseServiceObjectiveLevel": {
       "type": "string",
@@ -111,7 +103,6 @@
       "minLength": 1,
       "defaultValue": "S1"
     },
-
     "coreSqlDatabaseName": {
       "type": "string",
       "minLength": 1,
@@ -163,7 +154,6 @@
       "type": "securestring",
       "defaultValue": ""
     },
-
     "useApplicationInsights": {
       "type": "bool",
       "defaultValue": true
@@ -189,13 +179,15 @@
     "applicationInsightsCurrentBillingFeatures": {
       "type": "string",
       "defaultValue": "Basic",
-      "allowedValues": [ "Basic", "Application Insights Enterprise" ]
+      "allowedValues": [
+        "Basic",
+        "Application Insights Enterprise"
+      ]
     },
     "applicationInsightsDataVolumeCap": {
       "type": "string",
       "defaultValue": "0.33"
     },
-
     "singleHostingPlanName": {
       "type": "string",
       "minLength": 1,
@@ -277,7 +269,6 @@
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('forms', parameters('passwordSalt'))), uniqueString('forms', parameters('sqlServerPassword'), parameters('passwordSalt')), toUpper(uniqueString('forms', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '4@')]"
     },
-
     "authCertificateName": {
       "type": "string",
       "minLength": 1,
@@ -291,33 +282,48 @@
       "type": "securestring",
       "minLength": 1
     },
-
     "siClientSecret": {
       "type": "securestring",
       "minLength": 6,
       "defaultValue": "[toUpper(replace(guid(uniqueString('siClientSecret', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '-',''))]"
     },
-
     "telerikEncryptionKey": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('telerik', parameters('passwordSalt'))), uniqueString('telerik', parameters('sqlServerPassword'), parameters('passwordSalt')), toUpper(uniqueString('telerik', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '4@')]"
     },
-
     "passwordSalt": {
       "type": "securestring",
       "minLength": 1,
       "defaultValue": "[resourceGroup().id]"
     },
-
     "nodeJsVersion": {
-      "type" : "string",
-      "defaultValue" : "8.11.1"
+      "type": "string",
+      "defaultValue": "8.11.1"
     },
-
     "environmentType": {
       "type": "string",
       "defaultValue": "Non-Production"
+    },
+    "omsWorkspaceName": {
+      "defaultValue": "[concat(parameters('deploymentId'), '-oms')]",
+      "type": "string"
+    },
+    "omsWorkspaceMetricsRetentionDays": {
+      "defaultValue": 7,
+      "type": "int"
+    },
+    "omsWorkspaceSku": {
+      "defaultValue": "standalone",
+      "type": "string"
+    },
+    "omsCapSizeGb": {
+      "defaultValue": 1,
+      "type": "int"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -364,7 +370,6 @@
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "sqlServerVersion": {
             "value": "[parameters('sqlServerVersion')]"
           },
@@ -383,7 +388,6 @@
           "sqlDatabaseServiceObjectiveLevel": {
             "value": "[parameters('sqlDatabaseServiceObjectiveLevel')]"
           },
-
           "coreSqlDatabaseName": {
             "value": "[parameters('coreSqlDatabaseName')]"
           },
@@ -396,7 +400,6 @@
           "formsSqlDatabaseName": {
             "value": "[parameters('formsSqlDatabaseName')]"
           },
-
           "authCertificateName": {
             "value": "[parameters('authCertificateName')]"
           },
@@ -445,7 +448,6 @@
           "applicationInsightsDataVolumeCap": {
             "value": "[parameters('applicationInsightsDataVolumeCap')]"
           },
-
           "singleHostingPlanName": {
             "value": "[parameters('singleHostingPlanName')]"
           },
@@ -460,6 +462,21 @@
           },
           "singleWebAppName": {
             "value": "[parameters('singleWebAppName')]"
+          },
+          "omsWorkspaceName": {
+            "value": "[parameters('omsWorkspaceName')]"
+          },
+          "omsWorkspaceMetricsRetentionDays": {
+            "value": "[parameters('omsWorkspaceMetricsRetentionDays')]"
+          },
+          "omsWorkspaceSku": {
+            "value": "[parameters('omsWorkspaceSku')]"
+          },
+          "omsCapSizeGb": {
+            "value": "[parameters('omsCapSizeGb')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -480,27 +497,24 @@
           "infrastructure": {
             "value": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]"
           },
-
           "deploymentId": {
             "value": "[parameters('deploymentId')]"
           },
           "location": {
             "value": "[parameters('location')]"
-          },          
+          },
           "sitecoreAdminPassword": {
             "value": "[parameters('sitecoreAdminPassword')]"
           },
           "licenseXml": {
             "value": "[parameters('licenseXml')]"
           },
-
           "sqlServerLogin": {
             "value": "[parameters('sqlServerLogin')]"
           },
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "coreSqlDatabaseName": {
             "value": "[parameters('coreSqlDatabaseName')]"
           },
@@ -516,7 +530,6 @@
           "formsSqlDatabaseName": {
             "value": "[parameters('formsSqlDatabaseName')]"
           },
-
           "coreSqlDatabaseUserName": {
             "value": "[parameters('coreSqlDatabaseUserName')]"
           },
@@ -547,7 +560,6 @@
           "formsSqlDatabasePassword": {
             "value": "[parameters('formsSqlDatabasePassword')]"
           },
-
           "solrConnectionString": {
             "value": "[parameters('solrConnectionString')]"
           },
@@ -565,7 +577,6 @@
           "storeSitecoreCountersInApplicationInsights": {
             "value": "[parameters('storeSitecoreCountersInApplicationInsights')]"
           },
-
           "singleWebAppName": {
             "value": "[parameters('singleWebAppName')]"
           },
@@ -578,28 +589,29 @@
           "singleMsDeployPackageUrl": {
             "value": "[parameters('singleMsDeployPackageUrl')]"
           },
-
           "siClientSecret": {
             "value": "[parameters('siClientSecret')]"
           },
           "telerikEncryptionKey": {
             "value": "[parameters('telerikEncryptionKey')]"
           },
-
           "passwordSalt": {
             "value": "[parameters('passwordSalt')]"
           },
-
           "nodeJsVersion": {
             "value": "[parameters('nodeJsVersion')]"
           },
-
           "environmentType": {
             "value": "[parameters('environmentType')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
-      "dependsOn": [ "[resourceId('Microsoft.Resources/deployments', concat(parameters('deploymentId'), '-infrastructure'))]" ]
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', concat(parameters('deploymentId'), '-infrastructure'))]"
+      ]
     },
     {
       "copy": {
@@ -618,28 +630,23 @@
           "standard": {
             "value": {
               "infrastructure": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]",
-
               "deploymentId": "[parameters('deploymentId')]",
               "location": "[parameters('location')]",
               "sitecoreAdminPassword": "[parameters('sitecoreAdminPassword')]",
               "licenseXml": "[parameters('licenseXml')]",
-
               "sqlServerName": "[parameters('sqlServerName')]",
               "sqlServerLogin": "[parameters('sqlServerLogin')]",
               "sqlServerPassword": "[parameters('sqlServerPassword')]",
-
               "sqlServerVersion": "[parameters('sqlServerVersion')]",
               "sqlDatabaseCollation": "[parameters('sqlDatabaseCollation')]",
               "sqlDatabaseEdition": "[parameters('sqlDatabaseEdition')]",
               "sqlDatabaseMaxSize": "[parameters('sqlDatabaseMaxSize')]",
               "sqlBasicDatabaseServiceObjectiveLevel": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
               "sqlDatabaseServiceObjectiveLevel": "[parameters('sqlDatabaseServiceObjectiveLevel')]",
-
               "coreSqlDatabaseName": "[parameters('coreSqlDatabaseName')]",
               "masterSqlDatabaseName": "[parameters('masterSqlDatabaseName')]",
               "webSqlDatabaseName": "[parameters('webSqlDatabaseName')]",
               "formsSqlDatabaseName": "[parameters('formsSqlDatabaseName')]",
-
               "coreSqlDatabaseUserName": "[parameters('coreSqlDatabaseUserName')]",
               "coreSqlDatabasePassword": "[parameters('coreSqlDatabasePassword')]",
               "securitySqlDatabaseUserName": "[parameters('securitySqlDatabaseUserName')]",
@@ -657,21 +664,19 @@
               "searchServicePartitionCount": "[parameters('searchServicePartitionCount')]",
 
               "solrConnectionString": "[parameters('solrConnectionString')]",
-
               "useApplicationInsights": "[parameters('useApplicationInsights')]",
               "applicationInsightsName": "[parameters('applicationInsightsName')]",
               "applicationInsightsLocation": "[parameters('applicationInsightsLocation')]",
               "storeSitecoreCountersInApplicationInsights": "[parameters('storeSitecoreCountersInApplicationInsights')]",
-
               "singleHostingPlanName": "[parameters('singleHostingPlanName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
-
               "passwordSalt": "[parameters('passwordSalt')]",
-
               "environmentType": "[parameters('environmentType')]"
             }
           },
-          "extension": { "value": "[parameters('modules').items[copyIndex()].parameters]" }
+          "extension": {
+            "value": "[parameters('modules').items[copyIndex()].parameters]"
+          }
         }
       },
       "dependsOn": [

--- a/Sitecore 10.1.0/XMSingle/azuredeploy.parameters.json
+++ b/Sitecore 10.1.0/XMSingle/azuredeploy.parameters.json
@@ -1,5 +1,5 @@
-﻿{
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "deploymentId": {
@@ -26,10 +26,10 @@
     "licenseXml": {
       "value": ""
     },
-    "authCertificateBlob":{
+    "authCertificateBlob": {
       "value": ""
     },
-    "authCertificatePassword":{
+    "authCertificatePassword": {
       "value": ""
     }
   }

--- a/Sitecore 10.1.0/XMSingle/nested/application.json
+++ b/Sitecore 10.1.0/XMSingle/nested/application.json
@@ -1,11 +1,11 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
-    "webApiVersion": "2016-03-01",
+    "webApiVersion": "2018-02-01",
     "searchApiVersion": "2015-08-19",
     "searchRestApiVersion": "2017-11-11",
-    "applicationInsightsApiVersion": "2015-05-01",
+    "applicationInsightsApiVersion": "2020-02-02",
     "sqlServerFqdnTidy": "[trim(toLower(parameters('sqlServerFqdn')))]",
     "coreSqlDatabaseNameTidy": "[toLower(trim(parameters('coreSqlDatabaseName')))]",
     "securitySqlDatabaseNameTidy": "[toLower(trim(parameters('securitySqlDatabaseName')))]",
@@ -208,6 +208,10 @@
     "environmentType": {
       "type": "string",
       "defaultValue": "Non-Production"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -222,15 +226,15 @@
           {
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
-                "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
-                "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
-                "CertificateStoreLocation": "CurrentUser",
-                "PasswordRecoveryUrl": "[concat('https://', parameters('singleWebAppHostName'))]",
-                "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('applicationInsightsNameTidy')), variables('applicationInsightsApiVersion')).InstrumentationKey, '')]",
-                "License Xml": "[parameters('licenseXml')]",
-                "AllowedCorsOrigins": "[concat('https://', parameters('singleWebAppHostName'))]",
-                "ClientSecret": "[parameters('siClientSecret')]"
+              "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
+              "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+              "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
+              "CertificateStoreLocation": "CurrentUser",
+              "PasswordRecoveryUrl": "[concat('https://', parameters('singleWebAppHostName'))]",
+              "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('applicationInsightsNameTidy')), variables('applicationInsightsApiVersion')).InstrumentationKey, '')]",
+              "License Xml": "[parameters('licenseXml')]",
+              "AllowedCorsOrigins": "[concat('https://', parameters('singleWebAppHostName'))]",
+              "ClientSecret": "[parameters('siClientSecret')]"
             }
           }
         ]
@@ -244,6 +248,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
@@ -308,8 +313,9 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
-        "WEBSITE_NODE_DEFAULT_VERSION":"[parameters('nodeJsVersion')]",
+        "WEBSITE_NODE_DEFAULT_VERSION": "[parameters('nodeJsVersion')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [

--- a/Sitecore 10.1.0/XMSingle/nested/emptyAddon.json
+++ b/Sitecore 10.1.0/XMSingle/nested/emptyAddon.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "standard": {

--- a/Sitecore 10.1.0/XMSingle/nested/infrastructure.json
+++ b/Sitecore 10.1.0/XMSingle/nested/infrastructure.json
@@ -1,32 +1,28 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "serverFarmApiVersion": "2018-02-01",
-    "dbApiVersion": "2014-04-01-preview",
+    "dbApiVersion": "2022-05-01-preview",
     "searchApiVersion": "2015-08-19",
-    "applicationInsightsApiVersion": "2015-05-01",
+    "applicationInsightsApiVersion": "2020-02-02",
     "certificateApiVersion": "2014-11-01",
-
+    "omsWorkspaceApiVersion": "2017-03-15-preview",
     "sqlServerNameTidy": "[toLower(trim(parameters('sqlServerName')))]",
-
     "coreSqlDatabaseNameTidy": "[toLower(trim(parameters('coreSqlDatabaseName')))]",
     "webSqlDatabaseNameTidy": "[toLower(trim(parameters('webSqlDatabaseName')))]",
     "masterSqlDatabaseNameTidy": "[toLower(trim(parameters('masterSqlDatabaseName')))]",
     "formsSqlDatabaseNameTidy": "[toLower(trim(parameters('formsSqlDatabaseName')))]",
-
     "singleHostingPlanNameTidy": "[toLower(trim(parameters('singleHostingPlanName')))]",
-
     "singleWebAppNameTidy": "[toLower(trim(parameters('singleWebAppName')))]",
     "siWebAppNameTidy": "[toLower(trim(parameters('siWebAppName')))]",
 
     "searchServiceNameTidy": "[toLower(trim(parameters('searchServiceName')))]",
     "applicationInsightsNameTidy": "[toLower(trim(parameters('applicationInsightsName')))]",
     "applicationInsightsPricePlanTidy": "[toLower(trim(parameters('applicationInsightsPricePlan')))]",
-
     "authCertificateNameTidy": "[toLower(trim(parameters('authCertificateName')))]",
-
+    "omsWorkspaceNameTidy": "[toLower(trim(parameters('omsWorkspaceName')))]",
     "sitecoreTags": {
       "provider": "b51535c2-ab3e-4a68-95f8-e2e3c9a19299",
       "single": "single",
@@ -47,7 +43,6 @@
       "minLength": 1,
       "defaultValue": "[resourceGroup().location]"
     },
-
     "sqlServerName": {
       "type": "string",
       "minLength": 1,
@@ -61,7 +56,6 @@
       "type": "securestring",
       "minLength": 8
     },
-
     "sqlServerVersion": {
       "type": "string",
       "minLength": 1,
@@ -78,9 +72,8 @@
       "defaultValue": "Standard"
     },
     "sqlDatabaseMaxSize": {
-      "type": "string",
-      "minLength": 1,
-      "defaultValue": "268435456000"
+      "type": "int",
+      "defaultValue": 268435456000
     },
     "sqlBasicDatabaseServiceObjectiveLevel": {
       "type": "string",
@@ -92,7 +85,6 @@
       "minLength": 1,
       "defaultValue": "S1"
     },
-
     "coreSqlDatabaseName": {
       "type": "string",
       "minLength": 1,
@@ -161,13 +153,15 @@
     "applicationInsightsCurrentBillingFeatures": {
       "type": "string",
       "defaultValue": "Basic",
-      "allowedValues": [ "Basic", "Application Insights Enterprise" ]
+      "allowedValues": [
+        "Basic",
+        "Application Insights Enterprise"
+      ]
     },
     "applicationInsightsDataVolumeCap": {
       "type": "string",
       "defaultValue": "0.33"
     },
-
     "singleHostingPlanName": {
       "type": "string",
       "minLength": 1,
@@ -181,7 +175,6 @@
       "type": "int",
       "defaultValue": 1
     },
-
     "singleWebAppName": {
       "type": "string",
       "minLength": 1,
@@ -192,7 +185,6 @@
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-si')]"
     },
-
     "authCertificateName": {
       "type": "string",
       "minLength": 1,
@@ -205,6 +197,26 @@
     "authCertificatePassword": {
       "type": "securestring",
       "minLength": 1
+    },
+    "omsWorkspaceName": {
+      "defaultValue": "[concat(parameters('deploymentId'), '-oms')]",
+      "type": "string"
+    },
+    "omsWorkspaceMetricsRetentionDays": {
+      "defaultValue": 7,
+      "type": "int"
+    },
+    "omsWorkspaceSku": {
+      "defaultValue": "standalone",
+      "type": "string"
+    },
+    "omsCapSizeGb": {
+      "defaultValue": 1,
+      "type": "int"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -240,7 +252,7 @@
             "index.html"
           ]
         }
-      },      
+      },
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('singleHostingPlanNameTidy'))]"
       ],
@@ -285,7 +297,8 @@
       "properties": {
         "administratorLogin": "[parameters('sqlServerLogin')]",
         "administratorLoginPassword": "[parameters('sqlServerPassword')]",
-        "version": "[parameters('sqlServerVersion')]"
+        "version": "[parameters('sqlServerVersion')]",
+        "minimalTlsVersion": "[parameters('minTlsVersion')]"
       },
       "name": "[variables('sqlServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -301,16 +314,20 @@
             "startIpAddress": "0.0.0.0"
           },
           "name": "AllowAllAzureIps",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ]
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ]
         },
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -319,15 +336,17 @@
               "dependsOn": [
                 "[variables('coreSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('coreSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').core]"
@@ -336,11 +355,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -349,15 +370,17 @@
               "dependsOn": [
                 "[variables('masterSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('masterSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').master]"
@@ -366,11 +389,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -379,15 +404,17 @@
               "dependsOn": [
                 "[variables('webSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('webSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').web]"
@@ -396,11 +423,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -409,20 +438,22 @@
               "dependsOn": [
                 "[variables('formsSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('formsSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').forms]"
           }
-              }
+        }
       ]
     },
     {
@@ -450,11 +481,15 @@
       "location": "[parameters('applicationInsightsLocation')]",
       "properties": {
         "ApplicationId": "[variables('applicationInsightsNameTidy')]",
-        "Application_Type": "web"
+        "Application_Type": "web",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('omsWorkspaceNameTidy'))]"
       },
       "tags": {
         "provider": "[variables('sitecoreTags').provider]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('omsWorkspaceNameTidy'))]"
+      ]
     },
     {
       "type": "Microsoft.Web/certificates",
@@ -487,6 +522,25 @@
       "dependsOn": [
         "[resourceId('Microsoft.Insights/Components', variables('applicationInsightsNameTidy'))]"
       ],
+      "tags": {
+        "provider": "[variables('sitecoreTags').provider]"
+      }
+    },
+    {
+      "apiVersion": "[variables('omsWorkspaceApiVersion')]",
+      "name": "[variables('omsWorkspaceNameTidy')]",
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "condition": "[parameters('useApplicationInsights')]",
+      "location": "[parameters('applicationInsightsLocation')]",
+      "properties": {
+        "sku": {
+          "name": "[parameters('omsWorkspaceSku')]"
+        },
+        "retention": "[parameters('omsWorkspaceMetricsRetentionDays')]",
+        "workspaceCapping": {
+          "dailyQuotaGb": "[parameters('omsCapSizeGb')]"
+        }
+      },
       "tags": {
         "provider": "[variables('sitecoreTags').provider]"
       }

--- a/Sitecore 10.1.0/XP/README.md
+++ b/Sitecore 10.1.0/XP/README.md
@@ -8,20 +8,20 @@ This template creates a Sitecore XP Environment with all resources necessary to 
 
 Resources provisioned:
 
-  * Azure SQL databases : core, master, web, reporting, pools, tasks, forms, exm.master, refdata, smm, shard0, shard1, ma
-  * Azure Redis Cache for session state
-  * Sitecore roles: Content Delivery, Content Management, Processing
-	  * Hosting plans: one per role
-	  * Preconfigured Web Applications, based on the provided WebDeploy packages
-  * XConnect services: Search, Collection, Reference data, Marketing Automation, Marketing Automation Reporting
-	  * Hosting Plans: XConnect Basic, XConnect Resource Intensive
-	  * Preconfigured Web Applications, based on the provided WebDeploy packages
+* Azure SQL databases : core, master, web, reporting, pools, tasks, forms, exm.master, refdata, smm, shard0, shard1, ma
+* Azure Redis Cache for session state
+* Sitecore roles: Content Delivery, Content Management, Processing
+  * Hosting plans: one per role
+  * Preconfigured Web Applications, based on the provided WebDeploy packages
+* XConnect services: Search, Collection, Reference data, Marketing Automation, Marketing Automation Reporting
+  * Hosting Plans: XConnect Basic, XConnect Resource Intensive
+  * Preconfigured Web Applications, based on the provided WebDeploy packages
   * Azure Search Service
-  * (optional) Application Insights for diagnostics and monitoring
+* (optional) Application Insights for diagnostics and monitoring
 
 ## Parameters
 
-The **deploymentId** and **licenseXml** parameters in azuredeploy.parameters.json are filled in by the PowerShell script using **Name** and **LicenseXmlPath** parameters respectively.
+The **deploymentId** and **licenseXml** parameters in `azuredeploy.parameters.json` are filled in by the PowerShell script using **Name** and **LicenseXmlPath** parameters respectively.
 
 |Parameter                                  | Description
 |-------------------------------------------|---------------------------------------------------------------------------------------------
@@ -67,9 +67,10 @@ The **deploymentId** and **licenseXml** parameters in azuredeploy.parameters.jso
 > The default value is empty which means that Azure Search will be used.
 
 ## Deploying with App Service Environment v2
-> **Note**: Application Service Environment is not provisioned as part of this deployment template. Please reffer to official [documentation](https://docs.microsoft.com/en-us/azure/app-service/environment/intro) for information about ASE deployment and configuration. 
+
+> **Note**: Application Service Environment is not provisioned as part of this deployment template. Please refer to official [documentation](https://docs.microsoft.com/en-us/azure/app-service/environment/intro) for information about ASE deployment and configuration. 
 
 | Parameter                                 | Description
 --------------------------------------------|------------------------------------------------
 | aseName                                   | Name of deployed App Service Environment
-| aseResourceGroupName                      | Resource group where App Service Environment is deployed. Provide this value if ASE is hosted in different resouce group
+| aseResourceGroupName                      | Resource group where App Service Environment is deployed. Provide this value if ASE is hosted in different resource group

--- a/Sitecore 10.1.0/XP/addons/bootloader.json
+++ b/Sitecore 10.1.0/XP/addons/bootloader.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",

--- a/Sitecore 10.1.0/XP/addons/generic.json
+++ b/Sitecore 10.1.0/XP/addons/generic.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
@@ -28,7 +28,7 @@
         "reportingSqlDatabaseName": null,
         "cmWebAppName": null,
         "cdWebAppName": null,
-        "prcWebAppName": null,
+        "prcWebAppName": null
       }
     },
     "extension": {

--- a/Sitecore 10.1.0/XP/azuredeploy.json
+++ b/Sitecore 10.1.0/XP/azuredeploy.json
@@ -1,5 +1,5 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "resourcesApiVersion": "2018-05-01",
@@ -18,8 +18,7 @@
           {
             "name": "empty",
             "templateLink": "[concat(uri(parameters('templateLinkBase'), 'nested/emptyAddon.json'), parameters('templateLinkAccessToken'))]",
-            "parameters": {
-            }
+            "parameters": {}
           }
         ]
       }
@@ -31,13 +30,11 @@
           {
             "name": "empty-prerequisite",
             "templateLink": "[concat(uri(parameters('templateLinkBase'), 'nested/emptyAddon.json'), parameters('templateLinkAccessToken'))]",
-            "parameters": {
-            }
+            "parameters": {}
           }
         ]
       }
     },
-
     "templateLinkBase": {
       "type": "string",
       "minLength": 1,
@@ -47,7 +44,6 @@
       "type": "securestring",
       "defaultValue": ""
     },
-
     "deploymentId": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
@@ -57,7 +53,6 @@
       "minLength": 1,
       "defaultValue": "[resourceGroup().location]"
     },
-
     "sitecoreAdminPassword": {
       "type": "securestring",
       "minLength": 8
@@ -68,7 +63,15 @@
     },
     "sitecoreSKU": {
       "type": "string",
-      "allowedValues": [ "Extra Small", "Small", "Medium", "Large", "Extra Large", "2x Large", "3x Large" ],
+      "allowedValues": [
+        "Extra Small",
+        "Small",
+        "Medium",
+        "Large",
+        "Extra Large",
+        "2x Large",
+        "3x Large"
+      ],
       "defaultValue": "Extra Small",
       "metadata": {
         "description": "Sitecore SKU controls the sizes and service levels of the provisioned resources"
@@ -78,7 +81,6 @@
       "type": "securestring",
       "minLength": 32
     },
-
     "sqlServerName": {
       "type": "string",
       "minLength": 1,
@@ -92,7 +94,6 @@
       "type": "securestring",
       "minLength": 8
     },
-
     "sqlServerVersion": {
       "type": "string",
       "minLength": 1,
@@ -103,7 +104,6 @@
       "minLength": 1,
       "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
     },
-
     "coreSqlDatabaseName": {
       "type": "string",
       "minLength": 1,
@@ -184,7 +184,6 @@
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-processingenginestorage-db')]"
     },
-
     "coreSqlDatabaseUserName": {
       "type": "string",
       "minLength": 1,
@@ -315,7 +314,6 @@
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('processingengine', parameters('passwordSalt'))), uniqueString('processingengine', parameters('sqlServerPassword'), parameters('passwordSalt')), toUpper(uniqueString('processingengine', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '4@')]"
     },
-
     "redisCacheName": {
       "type": "string",
       "minLength": 1,
@@ -340,7 +338,6 @@
       "minLength": 1,
       "defaultValue": "xdb"
     },
-
     "solrConnectionString": {
       "type": "securestring",
       "defaultValue": ""
@@ -349,7 +346,6 @@
       "type": "securestring",
       "defaultValue": "[parameters('solrConnectionString')]"
     },
-
     "useApplicationInsights": {
       "type": "bool",
       "defaultValue": true
@@ -369,7 +365,10 @@
     },
     "xpPerformanceCountersType": {
       "type": "string",
-      "allowedValues": [ "Disable", "ApplicationInsights" ],
+      "allowedValues": [
+        "Disable",
+        "ApplicationInsights"
+      ],
       "defaultValue": "[if(parameters('storeSitecoreCountersInApplicationInsights'), 'ApplicationInsights', 'Disable')]"
     },
     "applicationInsightsPricePlan": {
@@ -377,7 +376,6 @@
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-ai-pp')]"
     },
-
     "siHostingPlanName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-si-hp')]"
@@ -411,7 +409,6 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-exm-dds-hp')]"
     },
-
     "siWebAppName": {
       "type": "string",
       "minLength": 1,
@@ -471,7 +468,6 @@
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-exm-dds')]"
     },
-
     "siMsDeployPackageUrl": {
       "type": "securestring",
       "minLength": 1
@@ -518,7 +514,6 @@
       "type": "securestring",
       "defaultValue": ""
     },
-
     "exmCryptographicKey": {
       "type": "securestring",
       "minLength": 64,
@@ -534,7 +529,6 @@
       "minLength": 64,
       "defaultValue": "[toUpper(replace(concat(guid(uniqueString('exmInternalApiKey', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), guid(uniqueString('exmInternalApiKey', parameters('sqlServerPassword'), parameters('passwordSalt')))), '-',''))]"
     },
-
     "securityClientIp": {
       "type": "string",
       "minLength": 1,
@@ -545,34 +539,32 @@
       "minLength": 1,
       "defaultValue": "0.0.0.0"
     },
-
     "siClientSecret": {
       "type": "securestring",
       "minLength": 6,
       "defaultValue": "[toUpper(replace(guid(uniqueString('siClientSecret', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '-',''))]"
     },
-
     "telerikEncryptionKey": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('telerik', parameters('passwordSalt'))), uniqueString('telerik', parameters('sqlServerPassword'), parameters('passwordSalt')), toUpper(uniqueString('telerik', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '4@')]"
     },
-
     "allowInvalidClientCertificates": {
       "type": "bool",
       "defaultValue": false
     },
-
     "passwordSalt": {
       "type": "securestring",
       "minLength": 1,
       "defaultValue": "[resourceGroup().id]"
     },
-
     "xcServerConfigurationEnvironment": {
       "type": "string",
       "defaultValue": "Production",
-      "allowedValues": [ "Development", "Production" ]
+      "allowedValues": [
+        "Development",
+        "Production"
+      ]
     },
     "authCertificateName": {
       "type": "string",
@@ -592,10 +584,12 @@
     "exmEdsProvider": {
       "type": "string",
       "minLength": 1,
-      "allowedValues": [ "CustomSMTP", "EmailCloud" ],
+      "allowedValues": [
+        "CustomSMTP",
+        "EmailCloud"
+      ],
       "defaultValue": "CustomSMTP"
     },
-
     "deployPlatform": {
       "type": "bool",
       "defaultValue": true
@@ -608,28 +602,26 @@
       "type": "bool",
       "defaultValue": false
     },
-    "aseName":{
+    "aseName": {
       "type": "string",
       "defaultValue": ""
     },
-    "aseResourceGroupName":{
+    "aseResourceGroupName": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
     },
-    "cmNodeJsVersion":{
+    "cmNodeJsVersion": {
       "type": "string",
       "defaultValue": "8.11.1"
     },
-    "cdNodeJsVersion":{
+    "cdNodeJsVersion": {
       "type": "string",
       "defaultValue": "8.11.1"
     },
-
     "environmentType": {
       "type": "string",
       "defaultValue": "Non-Production"
     },
-
     "azureServiceBusQueues": {
       "type": "array",
       "defaultValue": [
@@ -683,6 +675,14 @@
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-asb')]"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
+    },
+    "omsWorkspaceName": {
+      "type": "string",
+      "defaultValue": "[concat(toLower(parameters('deploymentId')), '-oms')]"
     }
   },
   "resources": [
@@ -723,7 +723,6 @@
           "sitecoreSKU": {
             "value": "[parameters('sitecoreSKU')]"
           },
-
           "sqlServerName": {
             "value": "[parameters('sqlServerName')]"
           },
@@ -733,14 +732,12 @@
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "sqlServerVersion": {
             "value": "[parameters('sqlServerVersion')]"
           },
           "sqlDatabaseCollation": {
             "value": "[parameters('sqlDatabaseCollation')]"
           },
-
           "coreSqlDatabaseName": {
             "value": "[parameters('coreSqlDatabaseName')]"
           },
@@ -791,7 +788,6 @@
           "applicationInsightsPricePlan": {
             "value": "[parameters('applicationInsightsPricePlan')]"
           },
-
           "siHostingPlanName": {
             "value": "[parameters('siHostingPlanName')]"
           },
@@ -804,7 +800,6 @@
           "prcHostingPlanName": {
             "value": "[parameters('prcHostingPlanName')]"
           },
-
           "siWebAppName": {
             "value": "[parameters('siWebAppName')]"
           },
@@ -817,7 +812,6 @@
           "prcWebAppName": {
             "value": "[parameters('prcWebAppName')]"
           },
-
           "authCertificateName": {
             "value": "[parameters('authCertificateName')]"
           },
@@ -827,12 +821,17 @@
           "authCertificatePassword": {
             "value": "[parameters('authCertificatePassword')]"
           },
-
           "aseName": {
             "value": "[parameters('aseName')]"
           },
-          "aseResourceGroupName":{
+          "aseResourceGroupName": {
             "value": "[parameters('aseResourceGroupName')]"
+          },
+          "omsWorkspaceName": {
+            "value": "[parameters('omsWorkspaceName')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -879,6 +878,9 @@
           },
           "azureServiceBusNamespaceName": {
             "value": "[parameters('azureServiceBusNamespaceName')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       }
@@ -902,15 +904,12 @@
           "sitecoreSKU": {
             "value": "[parameters('sitecoreSKU')]"
           },
-
           "sqlServerName": {
             "value": "[parameters('sqlServerName')]"
           },
-
           "sqlDatabaseCollation": {
             "value": "[parameters('sqlDatabaseCollation')]"
           },
-
           "shardMapManagerSqlDatabaseName": {
             "value": "[parameters('shardMapManagerSqlDatabaseName')]"
           },
@@ -923,14 +922,12 @@
           "refDataSqlDatabaseName": {
             "value": "[parameters('refDataSqlDatabaseName')]"
           },
-
           "xcBasicHostingPlanName": {
             "value": "[parameters('xcBasicHostingPlanName')]"
           },
           "xcResourceIntensiveHostingPlanName": {
             "value": "[parameters('xcResourceIntensiveHostingPlanName')]"
           },
-
           "xcRefDataWebAppName": {
             "value": "[parameters('xcRefDataWebAppName')]"
           },
@@ -940,11 +937,10 @@
           "xcSearchWebAppName": {
             "value": "[parameters('xcSearchWebAppName')]"
           },
-
           "aseName": {
             "value": "[parameters('aseName')]"
           },
-          "aseResourceGroupName":{
+          "aseResourceGroupName": {
             "value": "[parameters('aseResourceGroupName')]"
           }
         }
@@ -973,19 +969,16 @@
           "sitecoreSKU": {
             "value": "[parameters('sitecoreSKU')]"
           },
-
           "exmDdsHostingPlanName": {
             "value": "[parameters('exmDdsHostingPlanName')]"
           },
-
           "exmDdsWebAppName": {
             "value": "[parameters('exmDdsWebAppName')]"
           },
-
           "aseName": {
             "value": "[parameters('aseName')]"
           },
-          "aseResourceGroupName":{
+          "aseResourceGroupName": {
             "value": "[parameters('aseResourceGroupName')]"
           }
         }
@@ -1010,23 +1003,18 @@
           "sitecoreSKU": {
             "value": "[parameters('sitecoreSKU')]"
           },
-
           "sqlServerName": {
             "value": "[parameters('sqlServerName')]"
           },
-
           "sqlDatabaseCollation": {
             "value": "[parameters('sqlDatabaseCollation')]"
           },
-
           "maSqlDatabaseName": {
             "value": "[parameters('maSqlDatabaseName')]"
           },
-
           "xcBasicHostingPlanName": {
             "value": "[parameters('xcBasicHostingPlanName')]"
           },
-
           "maOpsWebAppName": {
             "value": "[parameters('maOpsWebAppName')]"
           },
@@ -1058,15 +1046,12 @@
           "sitecoreSKU": {
             "value": "[parameters('sitecoreSKU')]"
           },
-
           "sqlServerName": {
             "value": "[parameters('sqlServerName')]"
           },
-
           "sqlDatabaseCollation": {
             "value": "[parameters('sqlDatabaseCollation')]"
           },
-
           "processingEngineTasksSqlDatabaseName": {
             "value": "[parameters('processingEngineTasksSqlDatabaseName')]"
           },
@@ -1076,14 +1061,12 @@
           "reportingSqlDatabaseName": {
             "value": "[parameters('reportingSqlDatabaseName')]"
           },
-
           "xcBasicHostingPlanName": {
             "value": "[parameters('xcBasicHostingPlanName')]"
           },
           "xcResourceIntensiveHostingPlanName": {
             "value": "[parameters('xcResourceIntensiveHostingPlanName')]"
           },
-
           "cortexProcessingWebAppName": {
             "value": "[parameters('cortexProcessingWebAppName')]"
           },
@@ -1113,14 +1096,12 @@
           "infrastructureExm": {
             "value": "[if(parameters('deployExmDds'), reference(concat(parameters('deploymentId'), '-infrastructure-exm')).outputs.infrastructureExm.value, json('{}'))]"
           },
-
           "deploymentId": {
             "value": "[parameters('deploymentId')]"
           },
           "location": {
             "value": "[parameters('location')]"
           },
-
           "sitecoreAdminPassword": {
             "value": "[parameters('sitecoreAdminPassword')]"
           },
@@ -1130,14 +1111,12 @@
           "repAuthenticationApiKey": {
             "value": "[parameters('repAuthenticationApiKey')]"
           },
-
           "sqlServerLogin": {
             "value": "[parameters('sqlServerLogin')]"
           },
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "coreSqlDatabaseName": {
             "value": "[parameters('coreSqlDatabaseName')]"
           },
@@ -1168,7 +1147,6 @@
           "exmMasterSqlDatabaseName": {
             "value": "[parameters('exmMasterSqlDatabaseName')]"
           },
-
           "coreSqlDatabaseUserName": {
             "value": "[parameters('coreSqlDatabaseUserName')]"
           },
@@ -1229,7 +1207,6 @@
           "xcRefDataSqlDatabasePassword": {
             "value": "[parameters('xcRefDataSqlDatabasePassword')]"
           },
-
           "redisCacheName": {
             "value": "[parameters('redisCacheName')]"
           },
@@ -1240,7 +1217,6 @@
           "solrConnectionString": {
             "value": "[parameters('solrConnectionString')]"
           },
-
           "useApplicationInsights": {
             "value": "[parameters('useApplicationInsights')]"
           },
@@ -1250,7 +1226,6 @@
           "storeSitecoreCountersInApplicationInsights": {
             "value": "[parameters('storeSitecoreCountersInApplicationInsights')]"
           },
-
           "siWebAppName": {
             "value": "[parameters('siWebAppName')]"
           },
@@ -1281,7 +1256,6 @@
           "cortexReportingWebAppName": {
             "value": "[parameters('cortexReportingWebAppName')]"
           },
-
           "siMsDeployPackageUrl": {
             "value": "[parameters('siMsDeployPackageUrl')]"
           },
@@ -1300,50 +1274,44 @@
           "securityClientIpMask": {
             "value": "[parameters('securityClientIpMask')]"
           },
-
           "exmCryptographicKey": {
             "value": "[parameters('exmCryptographicKey')]"
           },
           "exmAuthenticationKey": {
             "value": "[parameters('exmAuthenticationKey')]"
           },
-
           "siClientSecret": {
             "value": "[parameters('siClientSecret')]"
           },
           "telerikEncryptionKey": {
             "value": "[parameters('telerikEncryptionKey')]"
           },
-
           "allowInvalidClientCertificates": {
             "value": "[parameters('allowInvalidClientCertificates')]"
           },
-
           "passwordSalt": {
             "value": "[parameters('passwordSalt')]"
           },
-
           "exmEdsProvider": {
             "value": "[parameters('exmEdsProvider')]"
           },
-
           "cmNodeJsVersion": {
             "value": "[parameters('cmNodeJsVersion')]"
           },
-
           "cdNodeJsVersion": {
             "value": "[parameters('cdNodeJsVersion')]"
           },
-
           "environmentType": {
             "value": "[parameters('environmentType')]"
           },
-
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusManageSharedAccessKeyName')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -1366,32 +1334,27 @@
           "infrastructure": {
             "value": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]"
           },
-
           "templateLinkAccessToken": {
             "value": "[parameters('templateLinkAccessToken')]"
           },
-
           "deploymentId": {
             "value": "[parameters('deploymentId')]"
           },
           "location": {
             "value": "[parameters('location')]"
           },
-
           "sitecoreAdminPassword": {
             "value": "[parameters('sitecoreAdminPassword')]"
           },
           "licenseXml": {
             "value": "[parameters('licenseXml')]"
           },
-
           "sqlServerLogin": {
             "value": "[parameters('sqlServerLogin')]"
           },
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "poolsSqlDatabaseName": {
             "value": "[parameters('poolsSqlDatabaseName')]"
           },
@@ -1410,7 +1373,6 @@
           "maSqlDatabaseName": {
             "value": "[parameters('maSqlDatabaseName')]"
           },
-
           "poolsSqlDatabaseUserName": {
             "value": "[parameters('poolsSqlDatabaseUserName')]"
           },
@@ -1441,18 +1403,15 @@
           "xcSearchIndexName": {
             "value": "[parameters('xcSearchIndexName')]"
           },
-
           "xcSolrConnectionString": {
             "value": "[parameters('xcSolrConnectionString')]"
           },
-
           "useApplicationInsights": {
             "value": "[parameters('useApplicationInsights')]"
           },
           "applicationInsightsName": {
             "value": "[parameters('applicationInsightsName')]"
           },
-
           "xcRefDataWebAppName": {
             "value": "[parameters('xcRefDataWebAppName')]"
           },
@@ -1462,7 +1421,6 @@
           "xcSearchWebAppName": {
             "value": "[parameters('xcSearchWebAppName')]"
           },
-
           "xcRefDataMsDeployPackageUrl": {
             "value": "[parameters('xcRefDataMsDeployPackageUrl')]"
           },
@@ -1472,31 +1430,29 @@
           "xcSearchMsDeployPackageUrl": {
             "value": "[parameters('xcSearchMsDeployPackageUrl')]"
           },
-
           "allowInvalidClientCertificates": {
             "value": "[parameters('allowInvalidClientCertificates')]"
           },
-
           "passwordSalt": {
             "value": "[parameters('passwordSalt')]"
           },
-
           "xcServerConfigurationEnvironment": {
             "value": "[parameters('xcServerConfigurationEnvironment')]"
           },
-
           "environmentType": {
             "value": "[parameters('environmentType')]"
           },
-
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusManageSharedAccessKeyName')]"
           },
           "xpPerformanceCountersType": {
             "value": "[parameters('xpPerformanceCountersType')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -1519,28 +1475,24 @@
           "infrastructure": {
             "value": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]"
           },
-
           "deploymentId": {
             "value": "[parameters('deploymentId')]"
           },
           "location": {
             "value": "[parameters('location')]"
           },
-
           "sitecoreAdminPassword": {
             "value": "[parameters('sitecoreAdminPassword')]"
           },
           "licenseXml": {
             "value": "[parameters('licenseXml')]"
           },
-
           "sqlServerLogin": {
             "value": "[parameters('sqlServerLogin')]"
           },
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "poolsSqlDatabaseName": {
             "value": "[parameters('poolsSqlDatabaseName')]"
           },
@@ -1553,7 +1505,6 @@
           "shardMapManagerSqlDatabaseName": {
             "value": "[parameters('shardMapManagerSqlDatabaseName')]"
           },
-
           "poolsSqlDatabaseUserName": {
             "value": "[parameters('poolsSqlDatabaseUserName')]"
           },
@@ -1578,14 +1529,12 @@
           "xcShardMapManagerSqlDatabasePassword": {
             "value": "[parameters('xcShardMapManagerSqlDatabasePassword')]"
           },
-
           "useApplicationInsights": {
             "value": "[parameters('useApplicationInsights')]"
           },
           "applicationInsightsName": {
             "value": "[parameters('applicationInsightsName')]"
           },
-
           "xcRefDataWebAppName": {
             "value": "[parameters('xcRefDataWebAppName')]"
           },
@@ -1601,7 +1550,6 @@
           "maRepWebAppName": {
             "value": "[parameters('maRepWebAppName')]"
           },
-
           "maOpsMsDeployPackageUrl": {
             "value": "[parameters('maOpsMsDeployPackageUrl')]"
           },
@@ -1612,27 +1560,26 @@
           "allowInvalidClientCertificates": {
             "value": "[parameters('allowInvalidClientCertificates')]"
           },
-
           "passwordSalt": {
             "value": "[parameters('passwordSalt')]"
           },
-
           "xcServerConfigurationEnvironment": {
             "value": "[parameters('xcServerConfigurationEnvironment')]"
           },
-
           "environmentType": {
             "value": "[parameters('environmentType')]"
           },
-
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusManageSharedAccessKeyName')]"
           },
           "xpPerformanceCountersType": {
             "value": "[parameters('xpPerformanceCountersType')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -1655,28 +1602,24 @@
           "infrastructure": {
             "value": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]"
           },
-
           "deploymentId": {
             "value": "[parameters('deploymentId')]"
           },
           "location": {
             "value": "[parameters('location')]"
           },
-
           "sitecoreAdminPassword": {
             "value": "[parameters('sitecoreAdminPassword')]"
           },
           "licenseXml": {
             "value": "[parameters('licenseXml')]"
           },
-
           "sqlServerLogin": {
             "value": "[parameters('sqlServerLogin')]"
           },
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "processingEngineTasksSqlDatabaseName": {
             "value": "[parameters('processingEngineTasksSqlDatabaseName')]"
           },
@@ -1686,7 +1629,6 @@
           "reportingSqlDatabaseName": {
             "value": "[parameters('reportingSqlDatabaseName')]"
           },
-
           "processingEngineSqlDatabaseUserName": {
             "value": "[parameters('processingEngineSqlDatabaseUserName')]"
           },
@@ -1699,14 +1641,12 @@
           "reportingSqlDatabasePassword": {
             "value": "[parameters('reportingSqlDatabasePassword')]"
           },
-
           "useApplicationInsights": {
             "value": "[parameters('useApplicationInsights')]"
           },
           "applicationInsightsName": {
             "value": "[parameters('applicationInsightsName')]"
           },
-
           "xcCollectWebAppName": {
             "value": "[parameters('xcCollectWebAppName')]"
           },
@@ -1719,38 +1659,36 @@
           "cortexReportingWebAppName": {
             "value": "[parameters('cortexReportingWebAppName')]"
           },
-
           "cortexProcessingMsDeployPackageUrl": {
             "value": "[parameters('cortexProcessingMsDeployPackageUrl')]"
           },
           "cortexReportingMsDeployPackageUrl": {
             "value": "[parameters('cortexReportingMsDeployPackageUrl')]"
           },
-
           "allowInvalidClientCertificates": {
             "value": "[parameters('allowInvalidClientCertificates')]"
           },
-
           "passwordSalt": {
             "value": "[parameters('passwordSalt')]"
           },
-
           "xcServerConfigurationEnvironment": {
             "value": "[parameters('xcServerConfigurationEnvironment')]"
           },
-
           "environmentType": {
             "value": "[parameters('environmentType')]"
           },
 
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusManageSharedAccessKeyName')]"
           },
           "xpPerformanceCountersType": {
             "value": "[parameters('xpPerformanceCountersType')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -1774,7 +1712,6 @@
           "infrastructure": {
             "value": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]"
           },
-
           "sitecoreAdminPassword": {
             "value": "[parameters('sitecoreAdminPassword')]"
           },
@@ -1784,21 +1721,18 @@
           "location": {
             "value": "[parameters('location')]"
           },
-
           "licenseXml": {
             "value": "[parameters('licenseXml')]"
           },
           "repAuthenticationApiKey": {
             "value": "[parameters('repAuthenticationApiKey')]"
           },
-
           "sqlServerLogin": {
             "value": "[parameters('sqlServerLogin')]"
           },
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "coreSqlDatabaseName": {
             "value": "[parameters('coreSqlDatabaseName')]"
           },
@@ -1861,14 +1795,12 @@
           "solrConnectionString": {
             "value": "[parameters('solrConnectionString')]"
           },
-
           "useApplicationInsights": {
             "value": "[parameters('useApplicationInsights')]"
           },
           "applicationInsightsName": {
             "value": "[parameters('applicationInsightsName')]"
           },
-
           "cmWebAppName": {
             "value": "[parameters('cmWebAppName')]"
           },
@@ -1893,7 +1825,6 @@
           "exmDdsWebAppName": {
             "value": "[parameters('exmDdsWebAppName')]"
           },
-
           "exmDdsMsDeployPackageUrl": {
             "value": "[parameters('exmDdsMsDeployPackageUrl')]"
           },
@@ -1903,14 +1834,12 @@
           "bootloaderMsDeployPackageUrl": {
             "value": "[parameters('bootloaderMsDeployPackageUrl')]"
           },
-
           "securityClientIp": {
             "value": "[parameters('securityClientIp')]"
           },
           "securityClientIpMask": {
             "value": "[parameters('securityClientIpMask')]"
           },
-
           "exmCryptographicKey": {
             "value": "[parameters('exmCryptographicKey')]"
           },
@@ -1920,35 +1849,32 @@
           "exmInternalApiKey": {
             "value": "[parameters('exmInternalApiKey')]"
           },
-
           "exmEdsProvider": {
             "value": "[parameters('exmEdsProvider')]"
           },
-
           "siClientSecret": {
             "value": "[parameters('siClientSecret')]"
           },
           "telerikEncryptionKey": {
             "value": "[parameters('telerikEncryptionKey')]"
           },
-
           "allowInvalidClientCertificates": {
             "value": "[parameters('allowInvalidClientCertificates')]"
           },
-
           "passwordSalt": {
             "value": "[parameters('passwordSalt')]"
           },
-
           "environmentType": {
             "value": "[parameters('environmentType')]"
           },
-
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusManageSharedAccessKeyName')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -1977,21 +1903,17 @@
           "standard": {
             "value": {
               "infrastructure": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]",
-
               "deploymentId": "[parameters('deploymentId')]",
               "location": "[parameters('location')]",
-
               "sitecoreAdminPassword": "[parameters('sitecoreAdminPassword')]",
               "licenseXml": "[parameters('licenseXml')]",
               "sitecoreSKU": "[parameters('sitecoreSKU')]",
               "repAuthenticationApiKey": "[parameters('repAuthenticationApiKey')]",
-
               "sqlServerName": "[parameters('sqlServerName')]",
               "sqlServerLogin": "[parameters('sqlServerLogin')]",
               "sqlServerPassword": "[parameters('sqlServerPassword')]",
               "sqlServerVersion": "[parameters('sqlServerVersion')]",
               "sqlDatabaseCollation": "[parameters('sqlDatabaseCollation')]",
-
               "coreSqlDatabaseName": "[parameters('coreSqlDatabaseName')]",
               "securitySqlDatabaseName": "[parameters('securitySqlDatabaseName')]",
               "masterSqlDatabaseName": "[parameters('masterSqlDatabaseName')]",
@@ -2005,9 +1927,7 @@
               "refDataSqlDatabaseName": "[parameters('refDataSqlDatabaseName')]",
               "processingEngineTasksSqlDatabaseName": "[parameters('processingEngineTasksSqlDatabaseName')]",
               "processingEngineStorageSqlDatabaseName": "[parameters('processingEngineStorageSqlDatabaseName')]",
-
               "maSqlDatabaseName": "[parameters('maSqlDatabaseName')]",
-
               "coreSqlDatabaseUserName": "[parameters('coreSqlDatabaseUserName')]",
               "coreSqlDatabasePassword": "[parameters('coreSqlDatabasePassword')]",
               "securitySqlDatabaseUserName": "[parameters('securitySqlDatabaseUserName')]",
@@ -2034,23 +1954,18 @@
               "searchServiceName": "[parameters('searchServiceName')]",
               "searchServiceLocation": "[parameters('searchServiceLocation')]",
               "xcSearchIndexName": "[parameters('xcSearchIndexName')]",
-
               "solrConnectionString": "[parameters('solrConnectionString')]",
               "xcSolrConnectionString": "[parameters('xcSolrConnectionString')]",
-
               "redisCacheName": "[parameters('redisCacheName')]",
-
               "useApplicationInsights": "[parameters('useApplicationInsights')]",
               "applicationInsightsName": "[parameters('applicationInsightsName')]",
               "applicationInsightsLocation": "[parameters('applicationInsightsLocation')]",
               "storeSitecoreCountersInApplicationInsights": "[parameters('storeSitecoreCountersInApplicationInsights')]",
-
               "cmHostingPlanName": "[parameters('cmHostingPlanName')]",
               "cdHostingPlanName": "[parameters('cdHostingPlanName')]",
               "prcHostingPlanName": "[parameters('prcHostingPlanName')]",
               "xcBasicHostingPlanName": "[parameters('xcBasicHostingPlanName')]",
               "xcResourceIntensiveHostingPlanName": "[parameters('xcResourceIntensiveHostingPlanName')]",
-
               "cmWebAppName": "[parameters('cmWebAppName')]",
               "cdWebAppName": "[parameters('cdWebAppName')]",
               "prcWebAppName": "[parameters('prcWebAppName')]",
@@ -2061,21 +1976,18 @@
               "cortexReportingWebAppName": "[parameters('cortexReportingWebAppName')]",
               "maOpsWebAppName": "[parameters('maOpsWebAppName')]",
               "maRepWebAppName": "[parameters('maRepWebAppName')]",
-
               "securityClientIp": "[parameters('securityClientIp')]",
               "securityClientIpMask": "[parameters('securityClientIpMask')]",
-
               "passwordSalt": "[parameters('passwordSalt')]",
-
               "xcServerConfigurationEnvironment": "[parameters('xcServerConfigurationEnvironment')]",
-
               "authCertificateBlob": "[parameters('authCertificateBlob')]",
               "authCertificatePassword": "[parameters('authCertificatePassword')]",
-
               "environmentType": "[parameters('environmentType')]"
             }
           },
-          "extension": { "value": "[parameters('modules').items[copyIndex()].parameters]" }
+          "extension": {
+            "value": "[parameters('modules').items[copyIndex()].parameters]"
+          }
         }
       },
       "dependsOn": [

--- a/Sitecore 10.1.0/XP/azuredeploy.parameters.json
+++ b/Sitecore 10.1.0/XP/azuredeploy.parameters.json
@@ -1,5 +1,5 @@
-﻿{
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "deploymentId": {

--- a/Sitecore 10.1.0/XP/nested/application-cortex-prc-rep.json
+++ b/Sitecore 10.1.0/XP/nested/application-cortex-prc-rep.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
-    "appInsightsApiVersion": "2015-05-01",
+    "appInsightsApiVersion": "2020-02-02",
     "sqlServerFqdnTidy": "[toLower(trim(parameters('sqlServerFqdn')))]",
     "processingEngineTasksSqlDatabaseNameTidy": "[toLower(trim(parameters('processingEngineTasksSqlDatabaseName')))]",
     "processingEngineStorageSqlDatabaseNameTidy": "[toLower(trim(parameters('processingEngineStorageSqlDatabaseName')))]",
@@ -13,7 +13,7 @@
     "xcCollectWebAppNameTidy": "[toLower(trim(parameters('xcCollectWebAppName')))]",
     "xcSearchWebAppNameTidy": "[toLower(trim(parameters('xcSearchWebAppName')))]",
     "appInsightsNameTidy": "[toLower(trim(parameters('applicationInsightsName')))]",
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
   "parameters": {
@@ -162,11 +162,11 @@
       "defaultValue": "Non-Production"
     },
 
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
     },
@@ -174,6 +174,10 @@
       "type": "string",
       "allowedValues": [ "Disable", "ApplicationInsights" ],
       "defaultValue": "Disable"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -212,6 +216,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
@@ -261,6 +266,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"

--- a/Sitecore 10.1.0/XP/nested/application-exm.json
+++ b/Sitecore 10.1.0/XP/nested/application-exm.json
@@ -1,11 +1,11 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "searchApiVersion": "2015-08-19",
     "searchRestApiVersion": "2017-11-11",
-    "appInsightsApiVersion": "2015-05-01",
+    "appInsightsApiVersion": "2020-02-02",
 
     "sqlServerFqdnTidy": "[trim(toLower(parameters('sqlServerFqdn')))]",
 
@@ -34,7 +34,7 @@
 
     "dedicatedDispatchService": "/sitecore%20modules/web/exm/dedicateddispatchservice.asmx",
 
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
   "parameters": {
@@ -334,13 +334,17 @@
       "defaultValue": "Non-Production"
     },
 
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -432,6 +436,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"

--- a/Sitecore 10.1.0/XP/nested/application-ma.json
+++ b/Sitecore 10.1.0/XP/nested/application-ma.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
-    "appInsightsApiVersion": "2015-05-01",
+    "appInsightsApiVersion": "2020-02-02",
     "sqlServerFqdnTidy": "[toLower(trim(parameters('sqlServerFqdn')))]",
     "poolsSqlDatabaseNameTidy": "[toLower(trim(parameters('poolsSqlDatabaseName')))]",
     "maSqlDatabaseNameTidy": "[toLower(trim(parameters('maSqlDatabaseName')))]",
@@ -15,7 +15,7 @@
     "maOpsWebAppNameTidy": "[toLower(trim(parameters('maOpsWebAppName')))]",
     "maRepWebAppNameTidy": "[toLower(trim(parameters('maRepWebAppName')))]",
     "appInsightsNameTidy": "[toLower(trim(parameters('applicationInsightsName')))]",
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
   "parameters": {
@@ -193,11 +193,11 @@
       "defaultValue": "Non-Production"
     },
 
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
     },
@@ -205,6 +205,10 @@
       "type": "string",
       "allowedValues": [ "Disable", "ApplicationInsights" ],
       "defaultValue": "Disable"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -286,6 +290,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
@@ -299,6 +304,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"

--- a/Sitecore 10.1.0/XP/nested/application-xc-search-as.json
+++ b/Sitecore 10.1.0/XP/nested/application-xc-search-as.json
@@ -1,10 +1,10 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "searchApiVersion": "2015-08-19",
-    "appInsightsApiVersion": "2015-05-01",
+    "appInsightsApiVersion": "2020-02-02",
 
     "sqlServerFqdnTidy": "[toLower(trim(parameters('sqlServerFqdn')))]",
 
@@ -20,7 +20,7 @@
 
     "refDataSqlDatabaseNameTidy": "[toLower(trim(parameters('refDataSqlDatabaseName')))]",
 
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
   "parameters": {
@@ -185,11 +185,11 @@
       "defaultValue": "Non-Production"
     },
 
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
     },
@@ -197,6 +197,10 @@
       "type": "string",
       "allowedValues": [ "Disable", "ApplicationInsights" ],
       "defaultValue": "Disable"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -248,6 +252,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       }

--- a/Sitecore 10.1.0/XP/nested/application-xc-search-solr.json
+++ b/Sitecore 10.1.0/XP/nested/application-xc-search-solr.json
@@ -1,9 +1,9 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
-    "appInsightsApiVersion": "2015-05-01",
+    "appInsightsApiVersion": "2020-02-02",
 
     "sqlServerFqdnTidy": "[toLower(trim(parameters('sqlServerFqdn')))]",
 
@@ -23,7 +23,7 @@
     "xcSolrConnectionStringParameters": "[replace(variables('xcSolrConnectionStringTidy'), variables('xcSolrConnectionStringBaseUri'), '')]",
     "xcSolrConnectionString": "[uri(variables('xcSolrConnectionStringBaseUriTidy'), concat(variables('xcSearchIndexNameTidy'), variables('xcSolrConnectionStringParameters')))]",
 
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
   "parameters": {
@@ -83,7 +83,7 @@
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-ma-db')]"
     },
-  "refDataSqlDatabaseName": {
+    "refDataSqlDatabaseName": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-refdata-db')]"
@@ -188,11 +188,11 @@
       "defaultValue": "Non-Production"
     },
 
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
     },
@@ -200,6 +200,10 @@
       "type": "string",
       "allowedValues": [ "Disable", "ApplicationInsights" ],
       "defaultValue": "Disable"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -248,6 +252,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       }

--- a/Sitecore 10.1.0/XP/nested/application-xc.json
+++ b/Sitecore 10.1.0/XP/nested/application-xc.json
@@ -1,10 +1,10 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "resourcesApiVersion": "2018-05-01",
     "webApiVersion": "2018-02-01",
-    "appInsightsApiVersion": "2015-05-01",
+    "appInsightsApiVersion": "2020-02-02",
 
     "sqlServerFqdnTidy": "[toLower(trim(parameters('sqlServerFqdn')))]",
 
@@ -22,7 +22,7 @@
 
     "searchProvider": "[if(empty(parameters('xcSolrConnectionString')), 'Azure', 'Solr')]",
 
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
   "parameters": {
@@ -228,11 +228,11 @@
       "defaultValue": "Non-Production"
     },
 
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
     },
@@ -240,6 +240,10 @@
       "type": "string",
       "allowedValues": [ "Disable", "ApplicationInsights" ],
       "defaultValue": "Disable"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -413,13 +417,16 @@
           },
 
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusAccessKeyName')]"
           },
           "xpPerformanceCountersType": {
             "value": "[parameters('xpPerformanceCountersType')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -526,13 +533,16 @@
           },
 
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusAccessKeyName')]"
           },
           "xpPerformanceCountersType": {
             "value": "[parameters('xpPerformanceCountersType')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -545,6 +555,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       }
@@ -554,6 +565,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },

--- a/Sitecore 10.1.0/XP/nested/application.json
+++ b/Sitecore 10.1.0/XP/nested/application.json
@@ -1,12 +1,12 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "searchApiVersion": "2015-08-19",
     "searchRestApiVersion": "2017-11-11",
-    "redisApiVersion": "2016-04-01",
-    "appInsightsApiVersion": "2015-05-01",
+    "redisApiVersion": "2020-06-01",
+    "appInsightsApiVersion": "2020-02-02",
 
     "sqlServerFqdnTidy": "[trim(toLower(parameters('sqlServerFqdn')))]",
 
@@ -44,7 +44,7 @@
     "searchServiceNameTidy": "[toLower(trim(parameters('searchServiceName')))]",
     "redisCacheNameTidy": "[toLower(trim(parameters('redisCacheName')))]",
 
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
   "parameters": {
@@ -420,11 +420,11 @@
       "minLength": 1,
       "defaultValue": "[resourceGroup().id]"
     },
-    "cmNodeJsVersion":{
+    "cmNodeJsVersion": {
       "type": "string",
       "defaultValue": "8.11.1"
     },
-    "cdNodeJsVersion":{
+    "cdNodeJsVersion": {
       "type": "string",
       "defaultValue": "8.11.1"
     },
@@ -434,13 +434,17 @@
       "defaultValue": "Non-Production"
     },
 
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -455,15 +459,15 @@
           {
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
-                "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
-                "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
-                "CertificateStoreLocation": "CurrentUser",
-                "PasswordRecoveryUrl": "[concat('https://', parameters('cmWebAppHostName'))]",
-                "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy')), variables('appInsightsApiVersion')).InstrumentationKey, '')]",
-                "License Xml": "[parameters('licenseXml')]",
-                "AllowedCorsOrigins": "[concat(variables('cmWebAppHostUrl'), '|', variables('exmDdsWebAppHostUrlOrEmpty'))]",
-                "ClientSecret": "[parameters('siClientSecret')]"
+              "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
+              "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+              "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
+              "CertificateStoreLocation": "CurrentUser",
+              "PasswordRecoveryUrl": "[concat('https://', parameters('cmWebAppHostName'))]",
+              "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy')), variables('appInsightsApiVersion')).InstrumentationKey, '')]",
+              "License Xml": "[parameters('licenseXml')]",
+              "AllowedCorsOrigins": "[concat(variables('cmWebAppHostUrl'), '|', variables('exmDdsWebAppHostUrlOrEmpty'))]",
+              "ClientSecret": "[parameters('siClientSecret')]"
             }
           }
         ]
@@ -477,6 +481,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
@@ -494,65 +499,65 @@
             "dbType": "SQL",
             "connectionString": "[concat('Data Source=tcp:', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=master;User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
             "setParameters": {
-                "Application Path": "[variables('cmWebAppNameTidy')]",
-                "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
-                "Core DB User Name": "[parameters('coreSqlDatabaseUserName')]",
-                "Core DB Password": "[parameters('coreSqlDatabasePassword')]",
-                "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
-                "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
-                "Security DB User Name": "[parameters('securitySqlDatabaseUserName')]",
-                "Security DB Password": "[parameters('securitySqlDatabasePassword')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
-                "Security Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
-                "Master DB User Name": "[parameters('masterSqlDatabaseUserName')]",
-                "Master DB Password": "[parameters('masterSqlDatabasePassword')]",
-                "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('masterSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
-                "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('masterSqlDatabaseNameTidy'),';User Id=', parameters('masterSqlDatabaseUserName'), ';Password=', parameters('masterSqlDatabasePassword'), ';')]",
-                "Web DB User Name": "[parameters('webSqlDatabaseUserName')]",
-                "Web DB Password": "[parameters('webSqlDatabasePassword')]",
-                "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('webSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
-                "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('webSqlDatabaseNameTidy'),';User Id=', parameters('webSqlDatabaseUserName'), ';Password=', parameters('webSqlDatabasePassword'), ';')]",
-                "XDB Reference Data Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('refDataSqlDatabaseNameTidy'),';User Id=', parameters('xcRefDataSqlDatabaseUserName'), ';Password=', parameters('xcRefDataSqlDatabasePassword'), ';')]",
-                "Experience Forms DB User Name": "[parameters('formsSqlDatabaseUserName')]",
-                "Experience Forms DB Password": "[parameters('formsSqlDatabasePassword')]",
-                "Experience Forms Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('formsSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
-                "Experience Forms Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('formsSqlDatabaseNameTidy'),';User Id=', parameters('formsSqlDatabaseUserName'), ';Password=', parameters('formsSqlDatabasePassword'), ';')]",
-                "EXM Master DB User Name": "[parameters('exmMasterSqlDatabaseUserName')]",
-                "EXM Master DB Password": "[parameters('exmMasterSqlDatabasePassword')]",
-                "EXM Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('exmMasterSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
-                "EXM Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('exmMasterSqlDatabaseNameTidy'),';User Id=', parameters('exmMasterSqlDatabaseUserName'), ';Password=', parameters('exmMasterSqlDatabasePassword'), ';')]",
-                "Processing Service Url": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('prcWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('reportingSqlDatabaseNameTidy'),';User Id=', parameters('reportingSqlDatabaseUserName'), ';Password=', parameters('reportingSqlDatabasePassword'), ';')]",
-                "Reporting Service Api Key": "[parameters('repAuthenticationApiKey')]",
-                "XConnect Collection": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcCollectWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "XConnect Search": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcSearchWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "XDB Reference Data Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcRefDataWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "XDB MA Reporting Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('maRepWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "XDB MA Ops Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('maOpsWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "Cortex Reporting Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('cortexReportingWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "Search Provider": "[variables('searchProvider')]",
-                "Cloud Search Connection String": "[if(equals(variables('searchProvider'), 'Azure'), concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchRestApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey), '')]",
-                "SOLR Connection String": "[parameters('solrConnectionString')]",
-                "Messaging Connection String": "[listkeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.ServiceBus/namespaces/authorizationRules', variables('azureServiceBusNamespaceNameTidy'), parameters('azureServiceBusAccessKeyName')), variables('azureServiceBusVersion')).primaryConnectionString]",
-                "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy')), variables('appInsightsApiVersion')).InstrumentationKey, '')]",
-                "Application Insights Role": "[if(parameters('useApplicationInsights'), 'CM', '')]",
-                "Store Sitecore Counters In Application Insights": "[if(parameters('useApplicationInsights'), string(parameters('storeSitecoreCountersInApplicationInsights')), 'false')]",
-                "Use Application Insights": "[string(parameters('useApplicationInsights'))]",
-                "IP Security Client IP": "[parameters('securityClientIp')]",
-                "IP Security Client IP Mask": "[parameters('securityClientIpMask')]",
-                "Sitecore Identity Authority": "[concat('https://', parameters('siWebAppHostName'))]",
-                "Sitecore Identity Secret": "[parameters('siClientSecret')]",
-                "EXM Cryptographic Key": "[parameters('exmCryptographicKey')]",
-                "EXM Authentication Key": "[parameters('exmAuthenticationKey')]",
-                "Telerik Encryption Key": "[parameters('telerikEncryptionKey')]",
-                "EXM EDS Provider": "[parameters('exmEdsProvider')]",
-                "XConnect Collection Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
-                "XDB Reference Data Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
-                "XDB MA Reporting Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
-                "XDB MA Ops Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
-                "Cortex Reporting Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
-                "Allow Invalid Client Certificates": "[parameters('allowInvalidClientCertificates')]",
-                "License Xml": "[parameters('licenseXml')]"
+              "Application Path": "[variables('cmWebAppNameTidy')]",
+              "Sitecore Admin New Password": "[parameters('sitecoreAdminPassword')]",
+              "Core DB User Name": "[parameters('coreSqlDatabaseUserName')]",
+              "Core DB Password": "[parameters('coreSqlDatabasePassword')]",
+              "Core Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+              "Security DB User Name": "[parameters('securitySqlDatabaseUserName')]",
+              "Security DB Password": "[parameters('securitySqlDatabasePassword')]",
+              "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
+              "Security Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
+              "Master DB User Name": "[parameters('masterSqlDatabaseUserName')]",
+              "Master DB Password": "[parameters('masterSqlDatabasePassword')]",
+              "Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('masterSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
+              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('masterSqlDatabaseNameTidy'),';User Id=', parameters('masterSqlDatabaseUserName'), ';Password=', parameters('masterSqlDatabasePassword'), ';')]",
+              "Web DB User Name": "[parameters('webSqlDatabaseUserName')]",
+              "Web DB Password": "[parameters('webSqlDatabasePassword')]",
+              "Web Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('webSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('webSqlDatabaseNameTidy'),';User Id=', parameters('webSqlDatabaseUserName'), ';Password=', parameters('webSqlDatabasePassword'), ';')]",
+              "XDB Reference Data Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('refDataSqlDatabaseNameTidy'),';User Id=', parameters('xcRefDataSqlDatabaseUserName'), ';Password=', parameters('xcRefDataSqlDatabasePassword'), ';')]",
+              "Experience Forms DB User Name": "[parameters('formsSqlDatabaseUserName')]",
+              "Experience Forms DB Password": "[parameters('formsSqlDatabasePassword')]",
+              "Experience Forms Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('formsSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
+              "Experience Forms Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('formsSqlDatabaseNameTidy'),';User Id=', parameters('formsSqlDatabaseUserName'), ';Password=', parameters('formsSqlDatabasePassword'), ';')]",
+              "EXM Master DB User Name": "[parameters('exmMasterSqlDatabaseUserName')]",
+              "EXM Master DB Password": "[parameters('exmMasterSqlDatabasePassword')]",
+              "EXM Master Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('exmMasterSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
+              "EXM Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('exmMasterSqlDatabaseNameTidy'),';User Id=', parameters('exmMasterSqlDatabaseUserName'), ';Password=', parameters('exmMasterSqlDatabasePassword'), ';')]",
+              "Processing Service Url": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('prcWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('reportingSqlDatabaseNameTidy'),';User Id=', parameters('reportingSqlDatabaseUserName'), ';Password=', parameters('reportingSqlDatabasePassword'), ';')]",
+              "Reporting Service Api Key": "[parameters('repAuthenticationApiKey')]",
+              "XConnect Collection": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcCollectWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "XConnect Search": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcSearchWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "XDB Reference Data Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcRefDataWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "XDB MA Reporting Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('maRepWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "XDB MA Ops Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('maOpsWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "Cortex Reporting Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('cortexReportingWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "Search Provider": "[variables('searchProvider')]",
+              "Cloud Search Connection String": "[if(equals(variables('searchProvider'), 'Azure'), concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchRestApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey), '')]",
+              "SOLR Connection String": "[parameters('solrConnectionString')]",
+              "Messaging Connection String": "[listkeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.ServiceBus/namespaces/authorizationRules', variables('azureServiceBusNamespaceNameTidy'), parameters('azureServiceBusAccessKeyName')), variables('azureServiceBusVersion')).primaryConnectionString]",
+              "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy')), variables('appInsightsApiVersion')).InstrumentationKey, '')]",
+              "Application Insights Role": "[if(parameters('useApplicationInsights'), 'CM', '')]",
+              "Store Sitecore Counters In Application Insights": "[if(parameters('useApplicationInsights'), string(parameters('storeSitecoreCountersInApplicationInsights')), 'false')]",
+              "Use Application Insights": "[string(parameters('useApplicationInsights'))]",
+              "IP Security Client IP": "[parameters('securityClientIp')]",
+              "IP Security Client IP Mask": "[parameters('securityClientIpMask')]",
+              "Sitecore Identity Authority": "[concat('https://', parameters('siWebAppHostName'))]",
+              "Sitecore Identity Secret": "[parameters('siClientSecret')]",
+              "EXM Cryptographic Key": "[parameters('exmCryptographicKey')]",
+              "EXM Authentication Key": "[parameters('exmAuthenticationKey')]",
+              "Telerik Encryption Key": "[parameters('telerikEncryptionKey')]",
+              "EXM EDS Provider": "[parameters('exmEdsProvider')]",
+              "XConnect Collection Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
+              "XDB Reference Data Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
+              "XDB MA Reporting Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
+              "XDB MA Ops Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
+              "Cortex Reporting Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
+              "Allow Invalid Client Certificates": "[parameters('allowInvalidClientCertificates')]",
+              "License Xml": "[parameters('licenseXml')]"
             }
           }
         ]
@@ -573,31 +578,31 @@
             "dbType": "SQL",
             "connectionString": "[concat('Data Source=tcp:', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=master;User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
             "setParameters": {
-                "Application Path": "[variables('cdWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
-                "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('webSqlDatabaseNameTidy'),';User Id=', parameters('webSqlDatabaseUserName'), ';Password=', parameters('webSqlDatabasePassword'), ';')]",
-                "Reference Data Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('refDataSqlDatabaseNameTidy'),';User Id=', parameters('xcRefDataSqlDatabaseUserName'), ';Password=', parameters('xcRefDataSqlDatabasePassword'), ';')]",
-                "Experience Forms Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('formsSqlDatabaseNameTidy'),';User Id=', parameters('formsSqlDatabaseUserName'), ';Password=', parameters('formsSqlDatabasePassword'), ';')]",
-                "EXM Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('exmMasterSqlDatabaseNameTidy'),';User Id=', parameters('exmMasterSqlDatabaseUserName'), ';Password=', parameters('exmMasterSqlDatabasePassword'), ';')]",
-                "Messaging Connection String": "[listkeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.ServiceBus/namespaces/authorizationRules', variables('azureServiceBusNamespaceNameTidy'), parameters('azureServiceBusAccessKeyName')), variables('azureServiceBusVersion')).primaryConnectionString]",
-                "XConnect Collection": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcCollectWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "XDB Reference Data Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcRefDataWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "XDB MA Ops Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('maOpsWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "Redis Sessions": "[concat(reference(resourceId('Microsoft.Cache/Redis', variables('redisCacheNameTidy')), variables('redisApiVersion')).hostName, ':', reference(resourceId('Microsoft.Cache/Redis', variables('redisCacheNameTidy')), variables('redisApiVersion')).sslPort, ',password=', listKeys(resourceId('Microsoft.Cache/Redis', variables('redisCacheNameTidy')), variables('redisApiVersion')).primaryKey, ',ssl=True,abortConnect=False')]",
-                "Search Provider": "[variables('searchProvider')]",
-                "Cloud Search Connection String": "[if(equals(variables('searchProvider'), 'Azure'), concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchRestApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey), '')]",
-                "SOLR Connection String": "[parameters('solrConnectionString')]",
-                "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy')), variables('appInsightsApiVersion')).InstrumentationKey, '')]",
-                "Application Insights Role": "[if(parameters('useApplicationInsights'), 'CD', '')]",
-                "Store Sitecore Counters In Application Insights": "[if(parameters('useApplicationInsights'), string(parameters('storeSitecoreCountersInApplicationInsights')), 'false')]",
-                "Use Application Insights": "[string(parameters('useApplicationInsights'))]",
-                "EXM Cryptographic Key": "[parameters('exmCryptographicKey')]",
-                "EXM Authentication Key": "[parameters('exmAuthenticationKey')]",
-                "XConnect Collection Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
-                "XDB Reference Data Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
-                "XDB MA Ops Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
-                "Allow Invalid Client Certificates": "[parameters('allowInvalidClientCertificates')]",
-                "License Xml": "[parameters('licenseXml')]"
+              "Application Path": "[variables('cdWebAppNameTidy')]",
+              "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
+              "Web Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('webSqlDatabaseNameTidy'),';User Id=', parameters('webSqlDatabaseUserName'), ';Password=', parameters('webSqlDatabasePassword'), ';')]",
+              "Reference Data Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('refDataSqlDatabaseNameTidy'),';User Id=', parameters('xcRefDataSqlDatabaseUserName'), ';Password=', parameters('xcRefDataSqlDatabasePassword'), ';')]",
+              "Experience Forms Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('formsSqlDatabaseNameTidy'),';User Id=', parameters('formsSqlDatabaseUserName'), ';Password=', parameters('formsSqlDatabasePassword'), ';')]",
+              "EXM Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('exmMasterSqlDatabaseNameTidy'),';User Id=', parameters('exmMasterSqlDatabaseUserName'), ';Password=', parameters('exmMasterSqlDatabasePassword'), ';')]",
+              "Messaging Connection String": "[listkeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.ServiceBus/namespaces/authorizationRules', variables('azureServiceBusNamespaceNameTidy'), parameters('azureServiceBusAccessKeyName')), variables('azureServiceBusVersion')).primaryConnectionString]",
+              "XConnect Collection": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcCollectWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "XDB Reference Data Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcRefDataWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "XDB MA Ops Client": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('maOpsWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "Redis Sessions": "[concat(reference(resourceId('Microsoft.Cache/Redis', variables('redisCacheNameTidy')), variables('redisApiVersion')).hostName, ':', reference(resourceId('Microsoft.Cache/Redis', variables('redisCacheNameTidy')), variables('redisApiVersion')).sslPort, ',password=', listKeys(resourceId('Microsoft.Cache/Redis', variables('redisCacheNameTidy')), variables('redisApiVersion')).primaryKey, ',ssl=True,abortConnect=False')]",
+              "Search Provider": "[variables('searchProvider')]",
+              "Cloud Search Connection String": "[if(equals(variables('searchProvider'), 'Azure'), concat('serviceUrl=https://', variables('searchServiceNameTidy'), '.search.windows.net;apiVersion=', variables('searchRestApiVersion'), ';apiKey=', listAdminKeys(resourceId('Microsoft.Search/searchServices', variables('searchServiceNameTidy')), variables('searchApiVersion')).primaryKey), '')]",
+              "SOLR Connection String": "[parameters('solrConnectionString')]",
+              "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy')), variables('appInsightsApiVersion')).InstrumentationKey, '')]",
+              "Application Insights Role": "[if(parameters('useApplicationInsights'), 'CD', '')]",
+              "Store Sitecore Counters In Application Insights": "[if(parameters('useApplicationInsights'), string(parameters('storeSitecoreCountersInApplicationInsights')), 'false')]",
+              "Use Application Insights": "[string(parameters('useApplicationInsights'))]",
+              "EXM Cryptographic Key": "[parameters('exmCryptographicKey')]",
+              "EXM Authentication Key": "[parameters('exmAuthenticationKey')]",
+              "XConnect Collection Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
+              "XDB Reference Data Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
+              "XDB MA Ops Client Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
+              "Allow Invalid Client Certificates": "[parameters('allowInvalidClientCertificates')]",
+              "License Xml": "[parameters('licenseXml')]"
             }
           }
         ]
@@ -618,28 +623,28 @@
             "dbType": "SQL",
             "connectionString": "[concat('Data Source=tcp:', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=master;User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
             "setParameters": {
-                "Application Path": "[variables('prcWebAppNameTidy')]",
-                "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
-                "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('masterSqlDatabaseNameTidy'),';User Id=', parameters('masterSqlDatabaseUserName'), ';Password=', parameters('masterSqlDatabasePassword'), ';')]",
-                "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('reportingSqlDatabaseNameTidy'),';User Id=', parameters('reportingSqlDatabaseUserName'), ';Password=', parameters('reportingSqlDatabasePassword'), ';')]",
-                "XDB Processing Pools Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('poolsSqlDatabaseNameTidy'),';User Id=', parameters('poolsSqlDatabaseUserName'), ';Password=', parameters('poolsSqlDatabasePassword'), ';')]",
-                "XDB Processing Tasks DB User Name": "[parameters('tasksSqlDatabaseUserName')]",
-                "XDB Processing Tasks DB Password": "[parameters('tasksSqlDatabasePassword')]",
-                "XDB Processing Tasks Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('tasksSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
-                "XDB Processing Tasks Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('tasksSqlDatabaseNameTidy'),';User Id=', parameters('tasksSqlDatabaseUserName'), ';Password=', parameters('tasksSqlDatabasePassword'), ';')]",
-                "XDB Reference Data Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('refDataSqlDatabaseNameTidy'),';User Id=', parameters('xcRefDataSqlDatabaseUserName'), ';Password=', parameters('xcRefDataSqlDatabasePassword'), ';')]",
-                "Reporting Service Api Key": "[parameters('repAuthenticationApiKey')]",
-                "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy')), variables('appInsightsApiVersion')).InstrumentationKey, '')]",
-                "Application Insights Role": "[if(parameters('useApplicationInsights'), 'Processing', '')]",
-                "Store Sitecore Counters In Application Insights": "[if(parameters('useApplicationInsights'), string(parameters('storeSitecoreCountersInApplicationInsights')), 'false')]",
-                "Use Application Insights": "[string(parameters('useApplicationInsights'))]",
-                "XConnect Collection": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcCollectWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
-                "IP Security Client IP": "[parameters('securityClientIp')]",
-                "IP Security Client IP Mask": "[parameters('securityClientIpMask')]",
-                "XConnect Collection Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
-                "Allow Invalid Client Certificates": "[parameters('allowInvalidClientCertificates')]",
-                "License Xml": "[parameters('licenseXml')]"
+              "Application Path": "[variables('prcWebAppNameTidy')]",
+              "Core Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+              "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('securitySqlDatabaseNameTidy'),';User Id=', parameters('securitySqlDatabaseUserName'), ';Password=', parameters('securitySqlDatabasePassword'), ';')]",
+              "Master Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('masterSqlDatabaseNameTidy'),';User Id=', parameters('masterSqlDatabaseUserName'), ';Password=', parameters('masterSqlDatabasePassword'), ';')]",
+              "Reporting Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('reportingSqlDatabaseNameTidy'),';User Id=', parameters('reportingSqlDatabaseUserName'), ';Password=', parameters('reportingSqlDatabasePassword'), ';')]",
+              "XDB Processing Pools Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('poolsSqlDatabaseNameTidy'),';User Id=', parameters('poolsSqlDatabaseUserName'), ';Password=', parameters('poolsSqlDatabasePassword'), ';')]",
+              "XDB Processing Tasks DB User Name": "[parameters('tasksSqlDatabaseUserName')]",
+              "XDB Processing Tasks DB Password": "[parameters('tasksSqlDatabasePassword')]",
+              "XDB Processing Tasks Admin Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('tasksSqlDatabaseNameTidy'),';User Id=', parameters('sqlServerLogin'), ';Password=', parameters('sqlServerPassword'), ';')]",
+              "XDB Processing Tasks Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('tasksSqlDatabaseNameTidy'),';User Id=', parameters('tasksSqlDatabaseUserName'), ';Password=', parameters('tasksSqlDatabasePassword'), ';')]",
+              "XDB Reference Data Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('refDataSqlDatabaseNameTidy'),';User Id=', parameters('xcRefDataSqlDatabaseUserName'), ';Password=', parameters('xcRefDataSqlDatabasePassword'), ';')]",
+              "Reporting Service Api Key": "[parameters('repAuthenticationApiKey')]",
+              "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('appInsightsNameTidy')), variables('appInsightsApiVersion')).InstrumentationKey, '')]",
+              "Application Insights Role": "[if(parameters('useApplicationInsights'), 'Processing', '')]",
+              "Store Sitecore Counters In Application Insights": "[if(parameters('useApplicationInsights'), string(parameters('storeSitecoreCountersInApplicationInsights')), 'false')]",
+              "Use Application Insights": "[string(parameters('useApplicationInsights'))]",
+              "XConnect Collection": "[concat('https://', reference(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites', variables('xcCollectWebAppNameTidy')), variables('webApiVersion')).hostNames[0])]",
+              "IP Security Client IP": "[parameters('securityClientIp')]",
+              "IP Security Client IP Mask": "[parameters('securityClientIpMask')]",
+              "XConnect Collection Certificate": "[concat('StoreName=My;StoreLocation=CurrentUser;FindType=FindByThumbprint;FindValue=', parameters('authCertificateThumbprint'))]",
+              "Allow Invalid Client Certificates": "[parameters('allowInvalidClientCertificates')]",
+              "License Xml": "[parameters('licenseXml')]"
             }
           }
         ]
@@ -653,9 +658,10 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
-        "WEBSITE_NODE_DEFAULT_VERSION":"[parameters('cdNodeJsVersion')]",
+        "WEBSITE_NODE_DEFAULT_VERSION": "[parameters('cdNodeJsVersion')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [
@@ -667,9 +673,10 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
-        "WEBSITE_NODE_DEFAULT_VERSION":"[parameters('cmNodeJsVersion')]",
+        "WEBSITE_NODE_DEFAULT_VERSION": "[parameters('cmNodeJsVersion')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [
@@ -681,6 +688,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"

--- a/Sitecore 10.1.0/XP/nested/emptyAddon.json
+++ b/Sitecore 10.1.0/XP/nested/emptyAddon.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "standard": {

--- a/Sitecore 10.1.0/XP/nested/infrastructure-asb-queues.json
+++ b/Sitecore 10.1.0/XP/nested/infrastructure-asb-queues.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "deploymentId": {
@@ -40,7 +40,7 @@
         }
     },
     "variables": {
-        "azureServiceBusVersion": "2017-04-01",
+        "azureServiceBusVersion": "2022-01-01-preview",
         "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
     },
     "resources": [

--- a/Sitecore 10.1.0/XP/nested/infrastructure-asb-topics.json
+++ b/Sitecore 10.1.0/XP/nested/infrastructure-asb-topics.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "deploymentId": {
@@ -24,7 +24,7 @@
         }
     },
     "variables": {
-        "azureServiceBusVersion": "2017-04-01",
+        "azureServiceBusVersion": "2022-01-01-preview",
         "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
     },
     "resources": [

--- a/Sitecore 10.1.0/XP/nested/infrastructure-asb.json
+++ b/Sitecore 10.1.0/XP/nested/infrastructure-asb.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "deploymentId": {
@@ -73,10 +73,14 @@
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-asb')]"
+    },
+    "minTlsVersion": {
+      "defaultValue": "1.2",
+      "type": "string"
     }
   },
   "variables": {
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "resourcesApiVersion": "2018-05-01",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
@@ -88,6 +92,9 @@
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('azureServiceBusSkuName')]"
+      },
+      "properties": {
+        "minimumTlsVersion": "[parameters('minTlsVersion')]"
       }
     },
     {

--- a/Sitecore 10.1.0/XP/nested/infrastructure-cortex-prc-rep.json
+++ b/Sitecore 10.1.0/XP/nested/infrastructure-cortex-prc-rep.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
-    "dbApiVersion": "2014-04-01-preview",
+    "dbApiVersion": "2022-05-01-preview",
 
     "sqlServerNameTidy": "[toLower(trim(parameters('sqlServerName')))]",
 
@@ -101,119 +101,119 @@
         "Extra Small": {
           "processingEngineTasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "processingEngineStorageSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "reportingSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           }
         },
         "Small": {
           "processingEngineTasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "processingEngineStorageSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "reportingSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           }
         },
         "Medium": {
           "processingEngineTasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "processingEngineStorageSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "reportingSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           }
         },
         "Large": {
           "processingEngineTasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "processingEngineStorageSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "reportingSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           }
         },
         "Extra Large": {
           "processingEngineTasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "processingEngineStorageSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S3"
           },
           "reportingSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           }
         },
         "2x Large": {
           "processingEngineTasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "processingEngineStorageSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S3"
           },
           "reportingSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S3"
           }
         },
         "3x Large": {
           "processingEngineTasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "processingEngineStorageSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S3"
           },
           "reportingSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S3"
           }
         }
@@ -230,11 +230,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('processingEngineTasksSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('resourceSizes').processingEngineTasksSqlDataBase.ServiceObjectiveLevel]",
+        "tier": "[parameters('resourceSizes').processingEngineTasksSqlDataBase.Edition]"
+      },
       "properties": {
-        "edition": "[parameters('resourceSizes').processingEngineTasksSqlDataBase.Edition]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('resourceSizes').processingEngineTasksSqlDataBase.MaxSize]",
-        "requestedServiceObjectiveName": "[parameters('resourceSizes').processingEngineTasksSqlDataBase.ServiceObjectiveLevel]"
+        "maxSizeBytes": "[parameters('resourceSizes').processingEngineTasksSqlDataBase.MaxSize]"
       },
       "resources": [
         {
@@ -243,9 +245,9 @@
           "dependsOn": [
             "[variables('processingEngineTasksSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -259,11 +261,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('processingEngineStorageSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('resourceSizes').processingEngineStorageSqlDataBase.ServiceObjectiveLevel]",
+        "tier": "[parameters('resourceSizes').processingEngineStorageSqlDataBase.Edition]"
+      },
       "properties": {
-        "edition": "[parameters('resourceSizes').processingEngineStorageSqlDataBase.Edition]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('resourceSizes').processingEngineStorageSqlDataBase.MaxSize]",
-        "requestedServiceObjectiveName": "[parameters('resourceSizes').processingEngineStorageSqlDataBase.ServiceObjectiveLevel]"
+        "maxSizeBytes": "[parameters('resourceSizes').processingEngineStorageSqlDataBase.MaxSize]"
       },
       "resources": [
         {
@@ -272,9 +276,9 @@
           "dependsOn": [
             "[variables('processingEngineStorageSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -288,11 +292,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('reportingSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('resourceSizes').reportingSqlDatabase.ServiceObjectiveLevel]",
+        "tier": "[parameters('resourceSizes').reportingSqlDatabase.Edition]"
+      },
       "properties": {
-        "edition": "[parameters('resourceSizes').reportingSqlDatabase.Edition]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('resourceSizes').reportingSqlDatabase.MaxSize]",
-        "requestedServiceObjectiveName": "[parameters('resourceSizes').reportingSqlDatabase.ServiceObjectiveLevel]"
+        "maxSizeBytes": "[parameters('resourceSizes').reportingSqlDatabase.MaxSize]"
       },
       "resources": [
         {
@@ -301,9 +307,9 @@
           "dependsOn": [
             "[variables('reportingSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],

--- a/Sitecore 10.1.0/XP/nested/infrastructure-exm.json
+++ b/Sitecore 10.1.0/XP/nested/infrastructure-exm.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
@@ -9,11 +9,11 @@
     "exmDdsWebAppNameTidy": "[toLower(trim(parameters('exmDdsWebAppName')))]",
     "useAse": "[not(empty(parameters('aseName')))]",
     "aseResourceId": "[resourceId(parameters('aseResourceGroupName'), 'Microsoft.Web/hostingEnvironments', parameters('aseName'))]",
-    "hostingPlanProperties":{
-      "exmDdsProperties":{
+    "hostingPlanProperties": {
+      "exmDdsProperties": {
         "name": "[variables('exmDdsHostingPlanNameTidy')]"
       },
-      "exmDdsPropertiesWithASE":{
+      "exmDdsPropertiesWithASE": {
         "name": "[variables('exmDdsHostingPlanNameTidy')]",
         "hostingEnvironmentProfile": {
           "id": "[variables('aseResourceId')]"
@@ -129,11 +129,11 @@
       "type": "object",
       "defaultValue": "[parameters('skuMap')[parameters('sitecoreSKU')]]"
     },
-    "aseName":{
+    "aseName": {
       "type": "string",
       "defaultValue": ""
     },
-    "aseResourceGroupName":{
+    "aseResourceGroupName": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
     }

--- a/Sitecore 10.1.0/XP/nested/infrastructure-ma.json
+++ b/Sitecore 10.1.0/XP/nested/infrastructure-ma.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
-    "dbApiVersion": "2014-04-01-preview",
+    "dbApiVersion": "2022-05-01-preview",
 
     "sqlServerNameTidy": "[toLower(trim(parameters('sqlServerName')))]",
 
@@ -81,49 +81,49 @@
         "Extra Small": {
           "maSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           }
         },
         "Small": {
           "maSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           }
         },
         "Medium": {
           "maSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           }
         },
         "Large": {
           "maSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           }
         },
         "Extra Large": {
           "maSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           }
         },
         "2x Large": {
           "maSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           }
         },
         "3x Large": {
           "maSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           }
         }
@@ -140,11 +140,13 @@
       "type": "Microsoft.Sql/servers/databases",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('resourceSizes').maSqlDatabase.ServiceObjectiveLevel]",
+        "tier": "[parameters('resourceSizes').maSqlDatabase.Edition]"
+      },
       "properties": {
-        "edition": "[parameters('resourceSizes').maSqlDatabase.Edition]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('resourceSizes').maSqlDatabase.MaxSize]",
-        "requestedServiceObjectiveName": "[parameters('resourceSizes').maSqlDatabase.ServiceObjectiveLevel]"
+        "maxSizeBytes": "[parameters('resourceSizes').maSqlDatabase.MaxSize]"
       },
       "resources": [
         {
@@ -153,9 +155,9 @@
           "dependsOn": [
             "[variables('maSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],

--- a/Sitecore 10.1.0/XP/nested/infrastructure-xc.json
+++ b/Sitecore 10.1.0/XP/nested/infrastructure-xc.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "serverFarmApiVersion": "2018-02-01",
-    "dbApiVersion": "2014-04-01-preview",
+    "dbApiVersion": "2022-05-01-preview",
 
     "sqlServerNameTidy": "[toLower(trim(parameters('sqlServerName')))]",
 
@@ -157,22 +157,22 @@
           },
           "refDataSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "shardMapManagerSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "xcShard0SqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "xcShard1SqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           }
         },
@@ -195,22 +195,22 @@
           },
           "refDataSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "shardMapManagerSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "xcShard0SqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "xcShard1SqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           }
         },
@@ -233,22 +233,22 @@
           },
           "refDataSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "shardMapManagerSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "xcShard0SqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "xcShard1SqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           }
         },
@@ -271,22 +271,22 @@
           },
           "refDataSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "shardMapManagerSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "xcShard0SqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "xcShard1SqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           }
         },
@@ -309,22 +309,22 @@
           },
           "refDataSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S3"
           },
           "shardMapManagerSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "xcShard0SqlDatabase": {
             "Edition": "Premium",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "P1"
           },
           "xcShard1SqlDatabase": {
             "Edition": "Premium",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "P1"
           }
         },
@@ -347,22 +347,22 @@
           },
           "refDataSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S3"
           },
           "shardMapManagerSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "xcShard0SqlDatabase": {
             "Edition": "Premium",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "P2"
           },
           "xcShard1SqlDatabase": {
             "Edition": "Premium",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "P2"
           }
         },
@@ -385,22 +385,22 @@
           },
           "refDataSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S3"
           },
           "shardMapManagerSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "xcShard0SqlDatabase": {
             "Edition": "Premium",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "P2"
           },
           "xcShard1SqlDatabase": {
             "Edition": "Premium",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "P2"
           }
         }
@@ -410,11 +410,11 @@
       "type": "object",
       "defaultValue": "[parameters('skuMap')[parameters('sitecoreSKU')]]"
     },
-    "aseName":{
+    "aseName": {
       "type": "string",
       "defaultValue": ""
     },
-    "aseResourceGroupName":{
+    "aseResourceGroupName": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
     }
@@ -483,11 +483,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('refDataSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('resourceSizes').refDataSqlDataBase.ServiceObjectiveLevel]",
+        "tier": "[parameters('resourceSizes').refDataSqlDataBase.Edition]"
+      },
       "properties": {
-        "edition": "[parameters('resourceSizes').refDataSqlDataBase.Edition]",
         "collation": "[variables('refDataSqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('resourceSizes').refDataSqlDataBase.MaxSize]",
-        "requestedServiceObjectiveName": "[parameters('resourceSizes').refDataSqlDataBase.ServiceObjectiveLevel]"
+        "maxSizeBytes": "[parameters('resourceSizes').refDataSqlDataBase.MaxSize]"
       },
       "resources": [
         {
@@ -496,9 +498,9 @@
           "dependsOn": [
             "[variables('refDataSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -537,11 +539,13 @@
       "name": "[concat(variables('sqlServerNameTidy'),'/',variables('shardMapManagerSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('resourceSizes').shardMapManagerSqlDatabase.ServiceObjectiveLevel]",
+        "tier": "[parameters('resourceSizes').shardMapManagerSqlDatabase.Edition]"
+      },
       "properties": {
-        "edition": "[parameters('resourceSizes').shardMapManagerSqlDatabase.Edition]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('resourceSizes').shardMapManagerSqlDatabase.MaxSize]",
-        "requestedServiceObjectiveName": "[parameters('resourceSizes').shardMapManagerSqlDatabase.ServiceObjectiveLevel]"
+        "maxSizeBytes": "[parameters('resourceSizes').shardMapManagerSqlDatabase.MaxSize]"
       },
       "resources": [
         {
@@ -550,9 +554,9 @@
           "dependsOn": [
             "[variables('shardMapManagerSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -566,11 +570,13 @@
       "name": "[concat(variables('sqlServerNameTidy'),'/',variables('shard0SqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('resourceSizes').xcShard0SqlDatabase.ServiceObjectiveLevel]",
+        "tier": "[parameters('resourceSizes').xcShard0SqlDatabase.Edition]"
+      },
       "properties": {
-        "edition": "[parameters('resourceSizes').xcShard0SqlDatabase.Edition]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('resourceSizes').xcShard0SqlDatabase.MaxSize]",
-        "requestedServiceObjectiveName": "[parameters('resourceSizes').xcShard0SqlDatabase.ServiceObjectiveLevel]"
+        "maxSizeBytes": "[parameters('resourceSizes').xcShard0SqlDatabase.MaxSize]"
       },
       "resources": [
         {
@@ -579,9 +585,9 @@
           "dependsOn": [
             "[variables('shard0SqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -595,11 +601,13 @@
       "name": "[concat(variables('sqlServerNameTidy'),'/',variables('shard1SqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('resourceSizes').xcShard1SqlDatabase.ServiceObjectiveLevel]",
+        "tier": "[parameters('resourceSizes').xcShard1SqlDatabase.Edition]"
+      },
       "properties": {
-        "edition": "[parameters('resourceSizes').xcShard1SqlDatabase.Edition]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('resourceSizes').xcShard1SqlDatabase.MaxSize]",
-        "requestedServiceObjectiveName": "[parameters('resourceSizes').xcShard1SqlDatabase.ServiceObjectiveLevel]"
+        "maxSizeBytes": "[parameters('resourceSizes').xcShard1SqlDatabase.MaxSize]"
       },
       "resources": [
         {
@@ -608,9 +616,9 @@
           "dependsOn": [
             "[variables('shard1SqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],

--- a/Sitecore 10.1.0/XP/nested/infrastructure.json
+++ b/Sitecore 10.1.0/XP/nested/infrastructure.json
@@ -1,17 +1,16 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "serverFarmApiVersion": "2018-02-01",
-    "dbApiVersion": "2014-04-01-preview",
+    "dbApiVersion": "2022-05-01-preview",
     "searchApiVersion": "2015-08-19",
-    "redisApiVersion": "2016-04-01",
-    "appInsightsApiVersion": "2015-05-01",
+    "redisApiVersion": "2020-06-01",
+    "appInsightsApiVersion": "2020-02-02",
     "certificateApiVersion": "2014-11-01",
-
+    "omsWorkspaceApiVersion": "2017-03-15-preview",
     "sqlServerNameTidy": "[toLower(trim(parameters('sqlServerName')))]",
-
     "coreSqlDatabaseNameTidy": "[toLower(trim(parameters('coreSqlDatabaseName')))]",
     "webSqlDatabaseNameTidy": "[toLower(trim(parameters('webSqlDatabaseName')))]",
     "masterSqlDatabaseNameTidy": "[toLower(trim(parameters('masterSqlDatabaseName')))]",
@@ -19,12 +18,10 @@
     "tasksSqlDatabaseNameTidy": "[toLower(trim(parameters('tasksSqlDatabaseName')))]",
     "formsSqlDatabaseNameTidy": "[toLower(trim(parameters('formsSqlDatabaseName')))]",
     "exmMasterSqlDatabaseNameTidy": "[toLower(trim(parameters('exmMasterSqlDatabaseName')))]",
-
     "siHostingPlanNameTidy": "[toLower(trim(parameters('siHostingPlanName')))]",
     "cmHostingPlanNameTidy": "[toLower(trim(parameters('cmHostingPlanName')))]",
     "cdHostingPlanNameTidy": "[toLower(trim(parameters('cdHostingPlanName')))]",
     "prcHostingPlanNameTidy": "[toLower(trim(parameters('prcHostingPlanName')))]",
-
     "siWebAppNameTidy": "[toLower(trim(parameters('siWebAppName')))]",
     "cmWebAppNameTidy": "[toLower(trim(parameters('cmWebAppName')))]",
     "cdWebAppNameTidy": "[toLower(trim(parameters('cdWebAppName')))]",
@@ -35,7 +32,7 @@
     "appInsightsNameTidy": "[toLower(trim(parameters('applicationInsightsName')))]",
     "applicationInsightsPricePlanTidy": "[toLower(trim(parameters('applicationInsightsPricePlan')))]",
     "authCertificateNameTidy": "[toLower(trim(parameters('authCertificateName')))]",
-
+    "omsWorkspaceNameTidy": "[toLower(trim(parameters('omsWorkspaceName')))]",
     "sitecoreTags": {
       "provider": "b51535c2-ab3e-4a68-95f8-e2e3c9a19299",
       "si": "si",
@@ -48,43 +45,42 @@
       "pools": "prc-pools",
       "tasks": "prc-tasks",
       "forms": "forms",
-      "exmmaster" : "exmmaster"
+      "exmmaster": "exmmaster"
     },
-
     "useAse": "[not(empty(parameters('aseName')))]",
     "aseResourceId": "[resourceId(parameters('aseResourceGroupName'), 'Microsoft.Web/hostingEnvironments', parameters('aseName'))]",
-    "hostingPlanProperties":{
-      "siProperties":{
+    "hostingPlanProperties": {
+      "siProperties": {
         "name": "[variables('siHostingPlanNameTidy')]"
       },
-      "siPropertiesWithASE":{
+      "siPropertiesWithASE": {
         "name": "[variables('siHostingPlanNameTidy')]",
         "hostingEnvironmentProfile": {
           "id": "[variables('aseResourceId')]"
         }
       },
-      "cmProperties":{
+      "cmProperties": {
         "name": "[variables('cmHostingPlanNameTidy')]"
       },
-      "cmPropertiesWithASE":{
+      "cmPropertiesWithASE": {
         "name": "[variables('cmHostingPlanNameTidy')]",
         "hostingEnvironmentProfile": {
           "id": "[variables('aseResourceId')]"
         }
       },
-      "cdProperties":{
+      "cdProperties": {
         "name": "[variables('cdHostingPlanNameTidy')]"
       },
-      "cdPropertiesWithASE":{
+      "cdPropertiesWithASE": {
         "name": "[variables('cdHostingPlanNameTidy')]",
         "hostingEnvironmentProfile": {
           "id": "[variables('aseResourceId')]"
         }
       },
-      "prcProperties":{
+      "prcProperties": {
         "name": "[variables('prcHostingPlanNameTidy')]"
       },
-      "prcPropertiesWithASE":{
+      "prcPropertiesWithASE": {
         "name": "[variables('prcHostingPlanNameTidy')]",
         "hostingEnvironmentProfile": {
           "id": "[variables('aseResourceId')]"
@@ -107,13 +103,20 @@
     },
     "sitecoreSKU": {
       "type": "string",
-      "allowedValues": [ "Extra Small", "Small", "Medium", "Large", "Extra Large", "2x Large", "3x Large" ],
+      "allowedValues": [
+        "Extra Small",
+        "Small",
+        "Medium",
+        "Large",
+        "Extra Large",
+        "2x Large",
+        "3x Large"
+      ],
       "defaultValue": "Extra Small",
       "metadata": {
         "description": "Sitecore SKU controls the sizes and service levels of the provisioned resources"
       }
     },
-
     "sqlServerName": {
       "type": "string",
       "minLength": 1,
@@ -127,7 +130,6 @@
       "type": "securestring",
       "minLength": 8
     },
-
     "sqlServerVersion": {
       "type": "string",
       "minLength": 1,
@@ -138,7 +140,6 @@
       "minLength": 1,
       "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
     },
-
     "coreSqlDatabaseName": {
       "type": "string",
       "minLength": 1,
@@ -179,7 +180,7 @@
       "type": "bool",
       "defaultValue": true
     },
-    
+
     "searchServiceName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-as')]"
@@ -216,7 +217,6 @@
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-ai-pp')]"
     },
-
     "siHostingPlanName": {
       "type": "string",
       "minLength": 1,
@@ -237,7 +237,6 @@
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-prc-hp')]"
     },
-
     "siWebAppName": {
       "type": "string",
       "minLength": 1,
@@ -271,7 +270,6 @@
       "type": "securestring",
       "minLength": 1
     },
-
     "skuMap": {
       "type": "secureObject",
       "defaultValue": {
@@ -310,37 +308,37 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "poolsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "tasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "exmMasterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "searchService": {
@@ -357,6 +355,13 @@
             "CurrentBillingFeatures": "Basic",
             "DataVolumeCap": {
               "Cap": 0.33
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 1
             }
           }
         },
@@ -395,37 +400,37 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "poolsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "tasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "exmMasterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "searchService": {
@@ -442,6 +447,13 @@
             "CurrentBillingFeatures": "Basic",
             "DataVolumeCap": {
               "Cap": 0.33
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 1
             }
           }
         },
@@ -480,37 +492,37 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "poolsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "tasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "exmMasterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "searchService": {
@@ -527,6 +539,13 @@
             "CurrentBillingFeatures": "Basic",
             "DataVolumeCap": {
               "Cap": 0.33
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 1
             }
           }
         },
@@ -565,37 +584,37 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "poolsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "tasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "exmMasterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "searchService": {
@@ -612,6 +631,13 @@
             "CurrentBillingFeatures": "Basic",
             "DataVolumeCap": {
               "Cap": 0.33
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 1
             }
           }
         },
@@ -650,37 +676,37 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "poolsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "tasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S0"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "exmMasterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "searchService": {
@@ -697,6 +723,13 @@
             "CurrentBillingFeatures": "Application Insights Enterprise",
             "DataVolumeCap": {
               "Cap": 1.8
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 2
             }
           }
         },
@@ -735,37 +768,37 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S3"
           },
           "poolsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "tasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "exmMasterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "searchService": {
@@ -782,6 +815,13 @@
             "CurrentBillingFeatures": "Application Insights Enterprise",
             "DataVolumeCap": {
               "Cap": 1.8
+            }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 2
             }
           }
         },
@@ -820,37 +860,37 @@
           },
           "coreSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "masterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "webSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S4"
           },
           "poolsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "tasksSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S1"
           },
           "formsSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "exmMasterSqlDatabase": {
             "Edition": "Standard",
-            "MaxSize": "268435456000",
+            "MaxSize": 268435456000,
             "ServiceObjectiveLevel": "S2"
           },
           "searchService": {
@@ -868,6 +908,13 @@
             "DataVolumeCap": {
               "Cap": 1.8
             }
+          },
+          "operationalInsightsWorkspace": {
+            "sku": "standalone",
+            "metricsRetentionDays": 7,
+            "workspaceCapping": {
+              "dailyQuotaGb": 2
+            }
           }
         }
       }
@@ -876,13 +923,21 @@
       "type": "object",
       "defaultValue": "[parameters('skuMap')[parameters('sitecoreSKU')]]"
     },
-    "aseName":{
+    "aseName": {
       "type": "string",
       "defaultValue": ""
     },
-    "aseResourceGroupName":{
+    "aseResourceGroupName": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
+    },
+    "omsWorkspaceName": {
+      "defaultValue": "[concat(parameters('deploymentId'), '-oms')]",
+      "type": "string"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -915,8 +970,8 @@
         "provider": "[variables('sitecoreTags').provider]",
         "logicalName": "[variables('sitecoreTags').cm]"
       },
-      "dependsOn": [ 
-        "[resourceId('Microsoft.Web/serverfarms', variables('siHostingPlanNameTidy'))]" 
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('siHostingPlanNameTidy'))]"
       ]
     },
     {
@@ -933,8 +988,8 @@
         "provider": "[variables('sitecoreTags').provider]",
         "logicalName": "[variables('sitecoreTags').cd]"
       },
-      "dependsOn": [ 
-        "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]" 
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('cmHostingPlanNameTidy'))]"
       ]
     },
     {
@@ -951,9 +1006,28 @@
         "provider": "[variables('sitecoreTags').provider]",
         "logicalName": "[variables('sitecoreTags').prc]"
       },
-      "dependsOn": [ 
-        "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]" 
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('cdHostingPlanNameTidy'))]"
       ]
+    },
+    {
+      "apiVersion": "[variables('omsWorkspaceApiVersion')]",
+      "name": "[variables('omsWorkspaceNameTidy')]",
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "condition": "[parameters('useApplicationInsights')]",
+      "location": "[parameters('applicationInsightsLocation')]",
+      "properties": {
+        "sku": {
+          "name": "[parameters('resourceSizes').operationalInsightsWorkspace.sku]"
+        },
+        "retention": "[parameters('resourceSizes').operationalInsightsWorkspace.metricsRetentionDays]",
+        "workspaceCapping": {
+          "dailyQuotaGb": "[parameters('resourceSizes').operationalInsightsWorkspace.workspaceCapping.dailyQuotaGb]"
+        }
+      },
+      "tags": {
+        "provider": "[variables('sitecoreTags').provider]"
+      }
     },
     {
       "type": "Microsoft.Web/sites",
@@ -1063,7 +1137,8 @@
       "properties": {
         "administratorLogin": "[parameters('sqlServerLogin')]",
         "administratorLoginPassword": "[parameters('sqlServerPassword')]",
-        "version": "[parameters('sqlServerVersion')]"
+        "version": "[parameters('sqlServerVersion')]",
+        "minimalTlsVersion": "[parameters('minTlsVersion')]"
       },
       "name": "[variables('sqlServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -1079,16 +1154,20 @@
             "startIpAddress": "0.0.0.0"
           },
           "name": "AllowAllAzureIps",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ]
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ]
         },
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').coreSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').coreSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').coreSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').coreSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').coreSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').coreSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -1097,15 +1176,17 @@
               "dependsOn": [
                 "[variables('coreSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('coreSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').core]"
@@ -1114,11 +1195,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').masterSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').masterSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').masterSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').masterSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').masterSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').masterSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -1127,28 +1210,32 @@
               "dependsOn": [
                 "[variables('masterSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('masterSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').master]"
           }
         },
-		    {
+        {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').webSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').webSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').webSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').webSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').webSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').webSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -1157,15 +1244,17 @@
               "dependsOn": [
                 "[variables('webSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('webSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').web]"
@@ -1174,11 +1263,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').poolsSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').poolsSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').poolsSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').poolsSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').poolsSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').poolsSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -1187,15 +1278,17 @@
               "dependsOn": [
                 "[variables('poolsSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('poolsSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').pools]"
@@ -1204,11 +1297,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').tasksSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').tasksSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').tasksSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').tasksSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').tasksSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').tasksSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -1217,15 +1312,17 @@
               "dependsOn": [
                 "[variables('tasksSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('tasksSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').tasks]"
@@ -1234,11 +1331,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').formsSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').formsSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').formsSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').formsSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').formsSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').formsSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -1247,15 +1346,17 @@
               "dependsOn": [
                 "[variables('formsSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('formsSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').forms]"
@@ -1264,11 +1365,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('resourceSizes').exmMasterSqlDatabase.ServiceObjectiveLevel]",
+            "tier": "[parameters('resourceSizes').exmMasterSqlDatabase.Edition]"
+          },
           "properties": {
-            "edition": "[parameters('resourceSizes').exmMasterSqlDatabase.Edition]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('resourceSizes').exmMasterSqlDatabase.MaxSize]",
-            "requestedServiceObjectiveName": "[parameters('resourceSizes').exmMasterSqlDatabase.ServiceObjectiveLevel]"
+            "maxSizeBytes": "[parameters('resourceSizes').exmMasterSqlDatabase.MaxSize]"
           },
           "resources": [
             {
@@ -1277,15 +1380,17 @@
               "dependsOn": [
                 "[variables('exmMasterSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('exmMasterSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').exmmaster]"
@@ -1321,7 +1426,8 @@
           "family": "[parameters('resourceSizes').redisCache.SkuFamily]",
           "capacity": "[parameters('resourceSizes').redisCache.SkuCapacity]"
         },
-        "enableNonSslPort": false
+        "enableNonSslPort": false,
+        "minimumTlsVersion": "[parameters('minTlsVersion')]"
       },
       "tags": {
         "provider": "[variables('sitecoreTags').provider]"
@@ -1335,11 +1441,15 @@
       "location": "[parameters('applicationInsightsLocation')]",
       "properties": {
         "ApplicationId": "[variables('appInsightsNameTidy')]",
-        "Application_Type": "web"
+        "Application_Type": "web",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('omsWorkspaceNameTidy'))]"
       },
       "tags": {
         "provider": "[variables('sitecoreTags').provider]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('omsWorkspaceNameTidy'))]"
+      ]
     },
     {
       "type": "Microsoft.Insights/Components/CurrentBillingFeatures",

--- a/Sitecore 10.1.0/XPSingle/README.md
+++ b/Sitecore 10.1.0/XPSingle/README.md
@@ -8,19 +8,19 @@ This template creates a Sitecore XP Single Environment using a minimal set of Az
 
 Resources provisioned:
 
-  * Azure SQL databases : core, master, web, reporting, pools, tasks, forms, refdata, smm, shard0, shard1, ma
-  * Sitecore roles: Content Delivery, Content Management, Processing as a single WebApp instance
-	  * Hosting plans: single hosting plan
-	  * Preconfigured Web Application, based on the provided WebDeploy package
-  * XConnect services: Search, Collection, Reference data, Marketing Automation, Marketing Automation Reporting as a single WebApp instance
-	  * Hosting plans: single hosting plan
-	  * Preconfigured Web Application, based on the provided WebDeploy package
-  * Azure Search Service
-  * (optional) Application Insights for diagnostics and monitoring
+* Azure SQL databases : core, master, web, reporting, pools, tasks, forms, refdata, smm, shard0, shard1, ma
+* Sitecore roles: Content Delivery, Content Management, Processing as a single WebApp instance
+  * Hosting plans: single hosting plan
+  * Preconfigured Web Application, based on the provided WebDeploy package
+* XConnect services: Search, Collection, Reference data, Marketing Automation, Marketing Automation Reporting as a single WebApp instance
+  * Hosting plans: single hosting plan
+  * Preconfigured Web Application, based on the provided WebDeploy package
+* Azure Search Service
+* (optional) Application Insights for diagnostics and monitoring
 
 ## Parameters
 
-The **deploymentId** and **licenseXml** parameters in azuredeploy.parameters.json are filled in by the PowerShell script using **Name** and **LicenseXmlPath** parameters respectively.
+The **deploymentId** and **licenseXml** parameters in `azuredeploy.parameters.json` are filled in by the PowerShell script using **Name** and **LicenseXmlPath** parameters respectively.
 
 |Parameter                                  | Description
 |-------------------------------------------|---------------------------------------------------------------------------------------------
@@ -39,9 +39,9 @@ The **deploymentId** and **licenseXml** parameters in azuredeploy.parameters.jso
 > to specify geographical region to deploy Azure Search Service. Default value is the resource
 > group location.
 > * The **applicationInsightsLocation** parameter can be added to the`azuredeploy.parameters.json`
-> to specify geographical region to deploy Application Insights. Default value is **East US**.
+>   to specify geographical region to deploy Application Insights. Default value is **East US**.
 > * The **useApplicationInsights** parameter can be added to the`azuredeploy.parameters.json`
-> to control whether Application Insights will be used for diagnostics and monitoring. Default value is **true**.
+>   to control whether Application Insights will be used for diagnostics and monitoring. Default value is **true**.
 
 ## Deploying with Solr Search
 

--- a/Sitecore 10.1.0/XPSingle/addons/bootloader.json
+++ b/Sitecore 10.1.0/XPSingle/addons/bootloader.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",

--- a/Sitecore 10.1.0/XPSingle/addons/generic.json
+++ b/Sitecore 10.1.0/XPSingle/addons/generic.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",

--- a/Sitecore 10.1.0/XPSingle/azuredeploy.json
+++ b/Sitecore 10.1.0/XPSingle/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "resourcesApiVersion": "2018-05-01",
@@ -18,8 +18,7 @@
           {
             "name": "empty",
             "templateLink": "[concat(uri(parameters('templateLinkBase'), 'nested/emptyAddon.json'), parameters('templateLinkAccessToken'))]",
-            "parameters": {
-            }
+            "parameters": {}
           }
         ]
       }
@@ -31,13 +30,11 @@
           {
             "name": "empty-prerequisite",
             "templateLink": "[concat(uri(parameters('templateLinkBase'), 'nested/emptyAddon.json'), parameters('templateLinkAccessToken'))]",
-            "parameters": {
-            }
+            "parameters": {}
           }
         ]
       }
     },
-
     "templateLinkBase": {
       "type": "string",
       "minLength": 1,
@@ -47,7 +44,6 @@
       "type": "securestring",
       "defaultValue": ""
     },
-
     "deploymentId": {
       "type": "string",
       "defaultValue": "[resourceGroup().name]"
@@ -57,7 +53,6 @@
       "minLength": 1,
       "defaultValue": "[resourceGroup().location]"
     },
-
     "sitecoreAdminPassword": {
       "type": "securestring",
       "minLength": 8
@@ -66,7 +61,6 @@
       "type": "securestring",
       "minLength": 1
     },
-
     "sqlServerName": {
       "type": "string",
       "minLength": 1,
@@ -80,7 +74,6 @@
       "type": "securestring",
       "minLength": 8
     },
-
     "sqlServerVersion": {
       "type": "string",
       "minLength": 1,
@@ -97,9 +90,8 @@
       "defaultValue": "Standard"
     },
     "sqlDatabaseMaxSize": {
-      "type": "string",
-      "minLength": 1,
-      "defaultValue": "268435456000"
+      "type": "int",
+      "defaultValue": 268435456000
     },
     "sqlBasicDatabaseServiceObjectiveLevel": {
       "type": "string",
@@ -111,7 +103,6 @@
       "minLength": 1,
       "defaultValue": "S1"
     },
-
     "coreSqlDatabaseName": {
       "type": "string",
       "minLength": 1,
@@ -192,7 +183,6 @@
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-processingenginestorage-db')]"
     },
-
     "coreSqlDatabaseUserName": {
       "type": "string",
       "minLength": 1,
@@ -339,7 +329,6 @@
       "minLength": 1,
       "defaultValue": "xdb"
     },
-
     "solrConnectionString": {
       "type": "securestring",
       "defaultValue": ""
@@ -348,7 +337,6 @@
       "type": "securestring",
       "defaultValue": "[parameters('solrConnectionString')]"
     },
-
     "useApplicationInsights": {
       "type": "bool",
       "defaultValue": true
@@ -368,7 +356,10 @@
     },
     "xpPerformanceCountersType": {
       "type": "string",
-      "allowedValues": [ "Disable", "ApplicationInsights" ],
+      "allowedValues": [
+        "Disable",
+        "ApplicationInsights"
+      ],
       "defaultValue": "[if(parameters('storeSitecoreCountersInApplicationInsights'), 'ApplicationInsights', 'Disable')]"
     },
     "applicationInsightsPricePlan": {
@@ -379,13 +370,15 @@
     "applicationInsightsCurrentBillingFeatures": {
       "type": "string",
       "defaultValue": "Basic",
-      "allowedValues": [ "Basic", "Application Insights Enterprise" ]
+      "allowedValues": [
+        "Basic",
+        "Application Insights Enterprise"
+      ]
     },
     "applicationInsightsDataVolumeCap": {
       "type": "string",
       "defaultValue": "0.33"
     },
-
     "xcSingleHostingPlanName": {
       "type": "string",
       "minLength": 1,
@@ -399,7 +392,6 @@
       "type": "int",
       "defaultValue": 1
     },
-
     "singleHostingPlanName": {
       "type": "string",
       "minLength": 1,
@@ -413,7 +405,6 @@
       "type": "int",
       "defaultValue": 1
     },
-
     "siWebAppName": {
       "type": "string",
       "minLength": 1,
@@ -429,7 +420,6 @@
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-xc-single')]"
     },
-
     "siMsDeployPackageUrl": {
       "type": "securestring",
       "minLength": 1
@@ -442,13 +432,11 @@
       "type": "securestring",
       "minLength": 1
     },
-
     "telerikEncryptionKey": {
       "type": "securestring",
       "minLength": 8,
       "defaultValue": "[concat(toUpper(uniqueString('telerik', parameters('passwordSalt'))), uniqueString('telerik', parameters('sqlServerPassword'), parameters('passwordSalt')), toUpper(uniqueString('telerik', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '4@')]"
     },
-
     "authCertificateName": {
       "type": "string",
       "minLength": 1,
@@ -464,19 +452,19 @@
       "minLength": 1,
       "defaultValue": ""
     },
-
     "siClientSecret": {
       "type": "securestring",
       "minLength": 6,
       "defaultValue": "[toUpper(replace(guid(uniqueString('siClientSecret', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), '-',''))]"
     },
-
     "exmEdsProvider": {
       "type": "string",
-      "allowedValues": [ "CustomSMTP", "EmailCloud" ],
+      "allowedValues": [
+        "CustomSMTP",
+        "EmailCloud"
+      ],
       "defaultValue": "CustomSMTP"
     },
-
     "exmCryptographicKey": {
       "type": "securestring",
       "minLength": 64,
@@ -487,34 +475,31 @@
       "minLength": 64,
       "defaultValue": "[toUpper(replace(concat(guid(uniqueString('exmAuthenticationKey', parameters('sitecoreAdminPassword'), parameters('passwordSalt'))), guid(uniqueString('exmAuthenticationKey', parameters('sqlServerPassword'), parameters('passwordSalt')))), '-',''))]"
     },
-
     "xcServerConfigurationEnvironment": {
       "type": "string",
       "defaultValue": "Production",
-      "allowedValues": [ "Development", "Production" ]
+      "allowedValues": [
+        "Development",
+        "Production"
+      ]
     },
-
     "allowInvalidClientCertificates": {
       "type": "bool",
       "defaultValue": false
     },
-
     "passwordSalt": {
       "type": "securestring",
       "minLength": 1,
       "defaultValue": "[resourceGroup().id]"
     },
-
     "nodeJsVersion": {
-      "type" : "string",
-      "defaultValue" : "8.11.1"
+      "type": "string",
+      "defaultValue": "8.11.1"
     },
-
     "environmentType": {
       "type": "string",
       "defaultValue": "Non-Production"
     },
-
     "azureServiceBusQueues": {
       "type": "array",
       "defaultValue": [
@@ -540,7 +525,7 @@
     "azureServiceBusTopics": {
       "type": "array",
       "defaultValue": [
-          "sitecore.processing.engine.abstractions~sitecore.processing.engine.abstractions.messages.taskstatus"
+        "sitecore.processing.engine.abstractions~sitecore.processing.engine.abstractions.messages.taskstatus"
       ]
     },
     "azureServiceBusSubscriptions": {
@@ -568,6 +553,26 @@
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-asb')]"
+    },
+    "minTlsVersion": {
+      "defaultValue": "1.2",
+      "type": "string"
+    },
+    "omsWorkspaceMetricsRetentionDays": {
+      "type": "int",
+      "defaultValue": 7
+    },
+    "omsCapSizeGb": {
+      "defaultValue": 1,
+      "type": "int"
+    },
+    "omsWorkspaceSku": {
+      "type": "string",
+      "defaultValue": "standalone"
+    },
+    "omsWorkspaceName": {
+      "type": "string",
+      "defaultValue": "[concat(toLower(parameters('deploymentId')), '-oms')]"
     }
   },
   "resources": [
@@ -605,7 +610,6 @@
           "location": {
             "value": "[parameters('location')]"
           },
-
           "sqlServerName": {
             "value": "[parameters('sqlServerName')]"
           },
@@ -615,7 +619,6 @@
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "sqlServerVersion": {
             "value": "[parameters('sqlServerVersion')]"
           },
@@ -634,7 +637,6 @@
           "sqlDatabaseServiceObjectiveLevel": {
             "value": "[parameters('sqlDatabaseServiceObjectiveLevel')]"
           },
-
           "coreSqlDatabaseName": {
             "value": "[parameters('coreSqlDatabaseName')]"
           },
@@ -695,7 +697,6 @@
           "applicationInsightsDataVolumeCap": {
             "value": "[parameters('applicationInsightsDataVolumeCap')]"
           },
-
           "singleHostingPlanName": {
             "value": "[parameters('singleHostingPlanName')]"
           },
@@ -705,14 +706,12 @@
           "singleHostingPlanSkuName": {
             "value": "[parameters('singleHostingPlanSkuName')]"
           },
-
           "siWebAppName": {
             "value": "[parameters('siWebAppName')]"
           },
           "singleWebAppName": {
             "value": "[parameters('singleWebAppName')]"
           },
-
           "authCertificateName": {
             "value": "[parameters('authCertificateName')]"
           },
@@ -721,6 +720,21 @@
           },
           "authCertificatePassword": {
             "value": "[parameters('authCertificatePassword')]"
+          },
+          "omsWorkspaceName": {
+            "value": "[parameters('omsWorkspaceName')]"
+          },
+          "omsWorkspaceSku": {
+            "value": "[parameters('omsWorkspaceSku')]"
+          },
+          "omsCapSizeGb": {
+            "value": "[parameters('omsCapSizeGb')]"
+          },
+          "omsWorkspaceMetricsRetentionDays": {
+            "value": "[parameters('omsWorkspaceMetricsRetentionDays')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -767,6 +781,9 @@
           },
           "azureServiceBusNamespaceName": {
             "value": "[parameters('azureServiceBusNamespaceName')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       }
@@ -787,7 +804,6 @@
           "location": {
             "value": "[parameters('location')]"
           },
-
           "sqlServerName": {
             "value": "[parameters('sqlServerName')]"
           },
@@ -803,7 +819,6 @@
           "sqlBasicDatabaseServiceObjectiveLevel": {
             "value": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
           },
-
           "shardMapManagerSqlDatabaseName": {
             "value": "[parameters('shardMapManagerSqlDatabaseName')]"
           },
@@ -828,7 +843,6 @@
           "reportingSqlDatabaseName": {
             "value": "[parameters('reportingSqlDatabaseName')]"
           },
-
           "xcSingleHostingPlanName": {
             "value": "[parameters('xcSingleHostingPlanName')]"
           },
@@ -838,7 +852,6 @@
           "xcSingleHostingPlanSkuCapacity": {
             "value": "[parameters('xcSingleHostingPlanSkuCapacity')]"
           },
-
           "xcSingleWebAppName": {
             "value": "[parameters('xcSingleWebAppName')]"
           }
@@ -861,28 +874,24 @@
           "infrastructure": {
             "value": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]"
           },
-
           "deploymentId": {
             "value": "[parameters('deploymentId')]"
           },
           "location": {
             "value": "[parameters('location')]"
           },
-
           "sitecoreAdminPassword": {
             "value": "[parameters('sitecoreAdminPassword')]"
           },
           "licenseXml": {
             "value": "[parameters('licenseXml')]"
           },
-
           "sqlServerLogin": {
             "value": "[parameters('sqlServerLogin')]"
           },
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "coreSqlDatabaseName": {
             "value": "[parameters('coreSqlDatabaseName')]"
           },
@@ -974,7 +983,6 @@
           "solrConnectionString": {
             "value": "[parameters('solrConnectionString')]"
           },
-
           "useApplicationInsights": {
             "value": "[parameters('useApplicationInsights')]"
           },
@@ -984,7 +992,6 @@
           "storeSitecoreCountersInApplicationInsights": {
             "value": "[parameters('storeSitecoreCountersInApplicationInsights')]"
           },
-
           "siWebAppName": {
             "value": "[parameters('siWebAppName')]"
           },
@@ -994,14 +1001,12 @@
           "xcSingleWebAppName": {
             "value": "[parameters('xcSingleWebAppName')]"
           },
-
           "siMsDeployPackageUrl": {
             "value": "[parameters('siMsDeployPackageUrl')]"
           },
           "singleMsDeployPackageUrl": {
             "value": "[parameters('singleMsDeployPackageUrl')]"
           },
-
           "exmEdsProvider": {
             "value": "[parameters('exmEdsProvider')]"
           },
@@ -1011,35 +1016,32 @@
           "exmAuthenticationKey": {
             "value": "[parameters('exmAuthenticationKey')]"
           },
-
           "siClientSecret": {
             "value": "[parameters('siClientSecret')]"
           },
           "telerikEncryptionKey": {
             "value": "[parameters('telerikEncryptionKey')]"
           },
-
           "allowInvalidClientCertificates": {
             "value": "[parameters('allowInvalidClientCertificates')]"
           },
-
           "passwordSalt": {
             "value": "[parameters('passwordSalt')]"
           },
-
           "nodeJsVersion": {
             "value": "[parameters('nodeJsVersion')]"
           },
-
           "environmentType": {
             "value": "[parameters('environmentType')]"
           },
-
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusManageSharedAccessKeyName')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -1061,32 +1063,27 @@
           "infrastructure": {
             "value": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]"
           },
-
           "templateLinkAccessToken": {
             "value": "[parameters('templateLinkAccessToken')]"
           },
-
           "deploymentId": {
             "value": "[parameters('deploymentId')]"
           },
           "location": {
             "value": "[parameters('location')]"
           },
-
           "sitecoreAdminPassword": {
             "value": "[parameters('sitecoreAdminPassword')]"
           },
           "licenseXml": {
             "value": "[parameters('licenseXml')]"
           },
-
           "sqlServerLogin": {
             "value": "[parameters('sqlServerLogin')]"
           },
           "sqlServerPassword": {
             "value": "[parameters('sqlServerPassword')]"
           },
-
           "poolsSqlDatabaseName": {
             "value": "[parameters('poolsSqlDatabaseName')]"
           },
@@ -1114,7 +1111,6 @@
           "processingEngineStorageSqlDatabaseName": {
             "value": "[parameters('processingEngineStorageSqlDatabaseName')]"
           },
-
           "poolsSqlDatabaseUserName": {
             "value": "[parameters('poolsSqlDatabaseUserName')]"
           },
@@ -1158,50 +1154,44 @@
           "xcSearchIndexName": {
             "value": "[parameters('xcSearchIndexName')]"
           },
-
           "xcSolrConnectionString": {
             "value": "[parameters('xcSolrConnectionString')]"
           },
-
           "useApplicationInsights": {
             "value": "[parameters('useApplicationInsights')]"
           },
           "applicationInsightsName": {
             "value": "[parameters('applicationInsightsName')]"
           },
-
           "xcSingleWebAppName": {
             "value": "[parameters('xcSingleWebAppName')]"
           },
-
           "xcSingleMsDeployPackageUrl": {
             "value": "[parameters('xcSingleMsDeployPackageUrl')]"
           },
-
           "xcServerConfigurationEnvironment": {
             "value": "[parameters('xcServerConfigurationEnvironment')]"
           },
-
           "allowInvalidClientCertificates": {
             "value": "[parameters('allowInvalidClientCertificates')]"
           },
-
           "passwordSalt": {
             "value": "[parameters('passwordSalt')]"
           },
-
           "environmentType": {
             "value": "[parameters('environmentType')]"
           },
-
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusManageSharedAccessKeyName')]"
           },
           "xpPerformanceCountersType": {
             "value": "[parameters('xpPerformanceCountersType')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       },
@@ -1227,13 +1217,10 @@
           "standard": {
             "value": {
               "infrastructure": "[reference(concat(parameters('deploymentId'), '-infrastructure')).outputs.infrastructure.value]",
-
               "deploymentId": "[parameters('deploymentId')]",
               "location": "[parameters('location')]",
-
               "sitecoreAdminPassword": "[parameters('sitecoreAdminPassword')]",
               "licenseXml": "[parameters('licenseXml')]",
-
               "sqlServerName": "[parameters('sqlServerName')]",
               "sqlServerLogin": "[parameters('sqlServerLogin')]",
               "sqlServerPassword": "[parameters('sqlServerPassword')]",
@@ -1243,7 +1230,6 @@
               "sqlDatabaseMaxSize": "[parameters('sqlDatabaseMaxSize')]",
               "sqlBasicDatabaseServiceObjectiveLevel": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
               "sqlDatabaseServiceObjectiveLevel": "[parameters('sqlDatabaseServiceObjectiveLevel')]",
-
               "coreSqlDatabaseName": "[parameters('coreSqlDatabaseName')]",
               "masterSqlDatabaseName": "[parameters('masterSqlDatabaseName')]",
               "webSqlDatabaseName": "[parameters('webSqlDatabaseName')]",
@@ -1259,7 +1245,6 @@
               "maSqlDatabaseName": "[parameters('maSqlDatabaseName')]",
               "processingEngineTasksSqlDatabaseName": "[parameters('processingEngineTasksSqlDatabaseName')]",
               "processingEngineStorageSqlDatabaseName": "[parameters('processingEngineStorageSqlDatabaseName')]",
-
               "coreSqlDatabaseUserName": "[parameters('coreSqlDatabaseUserName')]",
               "coreSqlDatabasePassword": "[parameters('coreSqlDatabasePassword')]",
               "masterSqlDatabaseUserName": "[parameters('masterSqlDatabaseUserName')]",
@@ -1291,32 +1276,26 @@
               "searchServiceReplicaCount": "[parameters('searchServiceReplicaCount')]",
               "searchServicePartitionCount": "[parameters('searchServicePartitionCount')]",
               "xcSearchIndexName": "[parameters('xcSearchIndexName')]",
-
               "solrConnectionString": "[parameters('solrConnectionString')]",
               "xcSolrConnectionString": "[parameters('xcSolrConnectionString')]",
-
               "useApplicationInsights": "[parameters('useApplicationInsights')]",
               "applicationInsightsName": "[parameters('applicationInsightsName')]",
               "applicationInsightsLocation": "[parameters('applicationInsightsLocation')]",
               "storeSitecoreCountersInApplicationInsights": "[parameters('storeSitecoreCountersInApplicationInsights')]",
-
               "xcSingleHostingPlanName": "[parameters('xcSingleHostingPlanName')]",
               "singleHostingPlanName": "[parameters('singleHostingPlanName')]",
-
               "xcSingleWebAppName": "[parameters('xcSingleWebAppName')]",
               "singleWebAppName": "[parameters('singleWebAppName')]",
-
               "passwordSalt": "[parameters('passwordSalt')]",
-
               "xcServerConfigurationEnvironment": "[parameters('xcServerConfigurationEnvironment')]",
-
               "authCertificateBlob": "[parameters('authCertificateBlob')]",
               "authCertificatePassword": "[parameters('authCertificatePassword')]",
-
               "environmentType": "[parameters('environmentType')]"
             }
           },
-          "extension": { "value": "[parameters('modules').items[copyIndex()].parameters]" }
+          "extension": {
+            "value": "[parameters('modules').items[copyIndex()].parameters]"
+          }
         }
       },
       "dependsOn": [

--- a/Sitecore 10.1.0/XPSingle/azuredeploy.parameters.json
+++ b/Sitecore 10.1.0/XPSingle/azuredeploy.parameters.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "deploymentId": {

--- a/Sitecore 10.1.0/XPSingle/nested/application-xc-as.json
+++ b/Sitecore 10.1.0/XPSingle/nested/application-xc-as.json
@@ -1,10 +1,10 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "searchApiVersion": "2015-08-19",
-    "appInsightsApiVersion": "2015-05-01",
+    "appInsightsApiVersion": "2020-02-02",
 
     "sqlServerFqdnTidy": "[toLower(trim(parameters('sqlServerFqdn')))]",
 
@@ -24,7 +24,7 @@
     "xcSearchIndexNameTidy": "[toLower(trim(parameters('xcSearchIndexName')))]",
     "appInsightsNameTidy": "[toLower(trim(parameters('applicationInsightsName')))]",
 
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
   "parameters": {
@@ -236,11 +236,11 @@
       "defaultValue": "Non-Production"
     },
 
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
     },
@@ -248,6 +248,10 @@
       "type": "string",
       "allowedValues": [ "Disable", "ApplicationInsights" ],
       "defaultValue": "Disable"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -318,6 +322,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"

--- a/Sitecore 10.1.0/XPSingle/nested/application-xc-solr.json
+++ b/Sitecore 10.1.0/XPSingle/nested/application-xc-solr.json
@@ -1,9 +1,9 @@
-﻿{
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
-    "appInsightsApiVersion": "2015-05-01",
+    "appInsightsApiVersion": "2020-02-02",
 
     "sqlServerFqdnTidy": "[toLower(trim(parameters('sqlServerFqdn')))]",
 
@@ -27,7 +27,7 @@
     "xcSolrConnectionStringParameters": "[replace(variables('xcSolrConnectionStringTidy'), variables('xcSolrConnectionStringBaseUri'), '')]",
     "xcSolrConnectionString": "[uri(variables('xcSolrConnectionStringBaseUriTidy'), concat(variables('xcSearchIndexNameTidy'), variables('xcSolrConnectionStringParameters')))]",
 
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
   "parameters": {
@@ -239,11 +239,11 @@
       "defaultValue": "Non-Production"
     },
 
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
     },
@@ -251,6 +251,10 @@
       "type": "string",
       "allowedValues": [ "Disable", "ApplicationInsights" ],
       "defaultValue": "Disable"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -318,6 +322,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"

--- a/Sitecore 10.1.0/XPSingle/nested/application-xc.json
+++ b/Sitecore 10.1.0/XPSingle/nested/application-xc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "resourcesApiVersion": "2018-05-01",
@@ -217,11 +217,11 @@
       "defaultValue": "Non-Production"
     },
 
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
     },
@@ -229,6 +229,10 @@
       "type": "string",
       "allowedValues": [ "Disable", "ApplicationInsights" ],
       "defaultValue": "Disable"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -372,13 +376,16 @@
           },
 
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusAccessKeyName')]"
           },
           "xpPerformanceCountersType": {
             "value": "[parameters('xpPerformanceCountersType')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       }
@@ -524,13 +531,16 @@
           },
 
           "azureServiceBusNamespaceName": {
-            "value" : "[parameters('azureServiceBusNamespaceName')]"
+            "value": "[parameters('azureServiceBusNamespaceName')]"
           },
           "azureServiceBusAccessKeyName": {
             "value": "[parameters('azureServiceBusAccessKeyName')]"
           },
           "xpPerformanceCountersType": {
             "value": "[parameters('xpPerformanceCountersType')]"
+          },
+          "minTlsVersion": {
+            "value": "[parameters('minTlsVersion')]"
           }
         }
       }

--- a/Sitecore 10.1.0/XPSingle/nested/application.json
+++ b/Sitecore 10.1.0/XPSingle/nested/application.json
@@ -1,11 +1,11 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
-    "webApiVersion": "2016-03-01",
+    "webApiVersion": "2018-02-01",
     "searchApiVersion": "2015-08-19",
     "searchRestApiVersion": "2017-11-11",
-    "applicationInsightsApiVersion": "2015-05-01",
+    "applicationInsightsApiVersion": "2020-02-02",
     "sqlServerFqdnTidy": "[trim(toLower(parameters('sqlServerFqdn')))]",
     "coreSqlDatabaseNameTidy": "[toLower(trim(parameters('coreSqlDatabaseName')))]",
     "securitySqlDatabaseNameTidy": "[toLower(trim(parameters('securitySqlDatabaseName')))]",
@@ -23,7 +23,7 @@
     "searchProvider": "[if(empty(parameters('solrConnectionString')), 'Azure', 'Solr')]",
     "searchServiceNameTidy": "[toLower(trim(parameters('searchServiceName')))]",
     "applicationInsightsNameTidy": "[toLower(trim(parameters('applicationInsightsName')))]",
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
   "parameters": {
@@ -237,12 +237,12 @@
       "type": "bool",
       "defaultValue": false
     },
-    "siWebAppHostName":{
+    "siWebAppHostName": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[parameters('infrastructure').siWebAppHostName]"
     },
-    "singleWebAppHostName":{
+    "singleWebAppHostName": {
       "type": "string",
       "minLength": 1,
       "defaultValue": "[parameters('infrastructure').singleWebAppHostName]"
@@ -321,13 +321,17 @@
       "type": "string",
       "defaultValue": "Non-Production"
     },
-    "azureServiceBusNamespaceName" : {
+    "azureServiceBusNamespaceName": {
       "type": "string",
       "minLength": 1
     },
-    "azureServiceBusAccessKeyName" : {
+    "azureServiceBusAccessKeyName": {
       "type": "string",
       "minLength": 1
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2"
     }
   },
   "resources": [
@@ -342,15 +346,15 @@
           {
             "packageUri": "[parameters('siMsDeployPackageUrl')]",
             "setParameters": {
-                "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
-                "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
-                "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
-                "CertificateStoreLocation": "CurrentUser",
-                "PasswordRecoveryUrl": "[concat('https://', parameters('singleWebAppHostName'))]",
-                "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('applicationInsightsNameTidy')), variables('applicationInsightsApiVersion')).InstrumentationKey, '')]",
-                "License Xml": "[parameters('licenseXml')]",
-                "AllowedCorsOrigins": "[concat('https://', parameters('singleWebAppHostName'))]",
-                "ClientSecret": "[parameters('siClientSecret')]"
+              "IIS Web Application Name": "[variables('siWebAppNameTidy')]",
+              "Security Connection String": "[concat('Encrypt=True;TrustServerCertificate=False;Data Source=', variables('sqlServerFqdnTidy'), ',1433;Initial Catalog=',variables('coreSqlDatabaseNameTidy'),';User Id=', parameters('coreSqlDatabaseUserName'), ';Password=', parameters('coreSqlDatabasePassword'), ';')]",
+              "CertificateThumbprint": "[parameters('authCertificateThumbprint')]",
+              "CertificateStoreLocation": "CurrentUser",
+              "PasswordRecoveryUrl": "[concat('https://', parameters('singleWebAppHostName'))]",
+              "Application Insights Instrumentation Key": "[if(parameters('useApplicationInsights'), reference(resourceId('Microsoft.Insights/Components', variables('applicationInsightsNameTidy')), variables('applicationInsightsApiVersion')).InstrumentationKey, '')]",
+              "License Xml": "[parameters('licenseXml')]",
+              "AllowedCorsOrigins": "[concat('https://', parameters('singleWebAppHostName'))]",
+              "ClientSecret": "[parameters('siClientSecret')]"
             }
           }
         ]
@@ -364,6 +368,7 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
@@ -454,9 +459,10 @@
       "type": "Microsoft.Web/sites/config",
       "apiVersion": "[variables('webApiVersion')]",
       "properties": {
+        "minTlsVersion": "[parameters('minTlsVersion')]",
         "WEBSITE_LOAD_CERTIFICATES": "[parameters('authCertificateThumbprint')]",
         "WEBSITE_DYNAMIC_CACHE": 0,
-        "WEBSITE_NODE_DEFAULT_VERSION":"[parameters('nodeJsVersion')]",
+        "WEBSITE_NODE_DEFAULT_VERSION": "[parameters('nodeJsVersion')]",
         "SITECORE_ENVIRONMENT_TYPE": "[parameters('environmentType')]"
       },
       "dependsOn": [

--- a/Sitecore 10.1.0/XPSingle/nested/emptyAddon.json
+++ b/Sitecore 10.1.0/XPSingle/nested/emptyAddon.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "standard": {

--- a/Sitecore 10.1.0/XPSingle/nested/infrastructure-asb-queues.json
+++ b/Sitecore 10.1.0/XPSingle/nested/infrastructure-asb-queues.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "deploymentId": {
@@ -40,7 +40,7 @@
         }
     },
     "variables": {
-        "azureServiceBusVersion": "2017-04-01",
+        "azureServiceBusVersion": "2022-01-01-preview",
         "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
     },
     "resources": [

--- a/Sitecore 10.1.0/XPSingle/nested/infrastructure-asb-topics.json
+++ b/Sitecore 10.1.0/XPSingle/nested/infrastructure-asb-topics.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "deploymentId": {
@@ -24,7 +24,7 @@
         }
     },
     "variables": {
-        "azureServiceBusVersion": "2017-04-01",
+        "azureServiceBusVersion": "2022-01-01-preview",
         "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
     },
     "resources": [

--- a/Sitecore 10.1.0/XPSingle/nested/infrastructure-asb.json
+++ b/Sitecore 10.1.0/XPSingle/nested/infrastructure-asb.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "deploymentId": {
@@ -73,10 +73,14 @@
       "type": "string",
       "minLength": 1,
       "defaultValue": "[concat(parameters('deploymentId'), '-asb')]"
+    },
+    "minTlsVersion": {
+      "defaultValue": "1.2",
+      "type": "string"
     }
   },
   "variables": {
-    "azureServiceBusVersion": "2017-04-01",
+    "azureServiceBusVersion": "2022-01-01-preview",
     "resourcesApiVersion": "2018-05-01",
     "azureServiceBusNamespaceNameTidy": "[toLower(trim(parameters('azureServiceBusNamespaceName')))]"
   },
@@ -88,6 +92,9 @@
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('azureServiceBusSkuName')]"
+      },
+      "properties": {
+        "minimumTlsVersion": "[parameters('minTlsVersion')]"
       }
     },
     {
@@ -200,7 +207,7 @@
         "forwardTo": "[toLower(parameters('azureServiceBusSubscriptions')[copyIndex()].subscription)]"
       },
       "dependsOn": [
-         "[resourceId('Microsoft.Resources/deployments', concat(parameters('deploymentId'), '-asb-queues'))]"
+        "[resourceId('Microsoft.Resources/deployments', concat(parameters('deploymentId'), '-asb-queues'))]"
       ]
     }
   ]

--- a/Sitecore 10.1.0/XPSingle/nested/infrastructure-xc.json
+++ b/Sitecore 10.1.0/XPSingle/nested/infrastructure-xc.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "serverFarmApiVersion": "2018-02-01",
-    "dbApiVersion": "2014-04-01-preview",
+    "dbApiVersion": "2022-05-01-preview",
 
     "sqlServerNameTidy": "[toLower(trim(parameters('sqlServerName')))]",
 
@@ -65,9 +65,8 @@
       "defaultValue": "Standard"
     },
     "sqlDatabaseMaxSize": {
-      "type": "string",
-      "minLength": 1,
-      "defaultValue": "268435456000"
+      "type": "int",
+      "defaultValue": 268435456000
     },
     "sqlBasicDatabaseServiceObjectiveLevel": {
       "type": "string",
@@ -79,8 +78,8 @@
       "type": "string",
       "minLength": 1,
       "defaultValue": "S1"
-    },    
-    
+    },
+
     "shardMapManagerSqlDatabaseName": {
       "type": "string",
       "minLength": 1,
@@ -190,11 +189,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('refDataSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+        "tier": "[parameters('sqlDatabaseEdition')]"
+      },
       "properties": {
-        "edition": "[parameters('sqlDatabaseEdition')]",
         "collation": "[variables('refDataSqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-        "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
       },
       "resources": [
         {
@@ -203,9 +204,9 @@
           "dependsOn": [
             "[variables('refDataSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -219,11 +220,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('reportingSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('sqlDatabaseServiceObjectiveLevel')]",
+        "tier": "[parameters('sqlDatabaseEdition')]"
+      },
       "properties": {
-        "edition": "[parameters('sqlDatabaseEdition')]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-        "requestedServiceObjectiveName": "[parameters('sqlDatabaseServiceObjectiveLevel')]"
+        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
       },
       "resources": [
         {
@@ -232,9 +235,9 @@
           "dependsOn": [
             "[variables('reportingSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -248,11 +251,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('shardMapManagerSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+        "tier": "[parameters('sqlDatabaseEdition')]"
+      },
       "properties": {
-        "edition": "[parameters('sqlDatabaseEdition')]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-        "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
       },
       "resources": [
         {
@@ -261,9 +266,9 @@
           "dependsOn": [
             "[variables('shardMapManagerSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -277,11 +282,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('shard0SqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+        "tier": "[parameters('sqlDatabaseEdition')]"
+      },
       "properties": {
-        "edition": "[parameters('sqlDatabaseEdition')]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-        "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
       },
       "resources": [
         {
@@ -290,9 +297,9 @@
           "dependsOn": [
             "[variables('shard0SqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -306,11 +313,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('shard1SqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+        "tier": "[parameters('sqlDatabaseEdition')]"
+      },
       "properties": {
-        "edition": "[parameters('sqlDatabaseEdition')]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-        "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
       },
       "resources": [
         {
@@ -319,9 +328,9 @@
           "dependsOn": [
             "[variables('shard1SqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -335,11 +344,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('maSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+        "tier": "[parameters('sqlDatabaseEdition')]"
+      },
       "properties": {
-        "edition": "[parameters('sqlDatabaseEdition')]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-        "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
       },
       "resources": [
         {
@@ -348,9 +359,9 @@
           "dependsOn": [
             "[variables('maSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -364,11 +375,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('processingEngineTasksSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+        "tier": "[parameters('sqlDatabaseEdition')]"
+      },
       "properties": {
-        "edition": "[parameters('sqlDatabaseEdition')]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-        "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
       },
       "resources": [
         {
@@ -377,9 +390,9 @@
           "dependsOn": [
             "[variables('processingEngineTasksSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],
@@ -393,11 +406,13 @@
       "name": "[concat(variables('sqlServerNameTidy'), '/', variables('processingEngineStorageSqlDatabaseNameTidy'))]",
       "location": "[parameters('location')]",
       "apiVersion": "[variables('dbApiVersion')]",
+      "sku": {
+        "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+        "tier": "[parameters('sqlDatabaseEdition')]"
+      },
       "properties": {
-        "edition": "[parameters('sqlDatabaseEdition')]",
         "collation": "[parameters('sqlDatabaseCollation')]",
-        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-        "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+        "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
       },
       "resources": [
         {
@@ -406,9 +421,9 @@
           "dependsOn": [
             "[variables('processingEngineStorageSqlDatabaseNameTidy')]"
           ],
-          "apiVersion": "2014-04-01",
+          "apiVersion": "[variables('dbApiVersion')]",
           "properties": {
-            "status": "Enabled"
+            "state": "Enabled"
           }
         }
       ],

--- a/Sitecore 10.1.0/XPSingle/nested/infrastructure.json
+++ b/Sitecore 10.1.0/XPSingle/nested/infrastructure.json
@@ -1,16 +1,15 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
     "webApiVersion": "2018-02-01",
     "serverFarmApiVersion": "2018-02-01",
-    "dbApiVersion": "2014-04-01-preview",
+    "dbApiVersion": "2022-05-01-preview",
     "searchApiVersion": "2015-08-19",
-    "applicationInsightsApiVersion": "2015-05-01",
+    "applicationInsightsApiVersion": "2020-02-02",
     "certificateApiVersion": "2014-11-01",
-
+    "omsWorkspaceApiVersion": "2017-03-15-preview",
     "sqlServerNameTidy": "[toLower(trim(parameters('sqlServerName')))]",
-
     "coreSqlDatabaseNameTidy": "[toLower(trim(parameters('coreSqlDatabaseName')))]",
     "webSqlDatabaseNameTidy": "[toLower(trim(parameters('webSqlDatabaseName')))]",
     "masterSqlDatabaseNameTidy": "[toLower(trim(parameters('masterSqlDatabaseName')))]",
@@ -18,18 +17,15 @@
     "tasksSqlDatabaseNameTidy": "[toLower(trim(parameters('tasksSqlDatabaseName')))]",
     "formsSqlDatabaseNameTidy": "[toLower(trim(parameters('formsSqlDatabaseName')))]",
     "exmMasterSqlDatabaseNameTidy": "[toLower(trim(parameters('exmMasterSqlDatabaseName')))]",
-
     "singleHostingPlanNameTidy": "[toLower(trim(parameters('singleHostingPlanName')))]",
-
     "siWebAppNameTidy": "[toLower(trim(parameters('siWebAppName')))]",
     "singleWebAppNameTidy": "[toLower(trim(parameters('singleWebAppName')))]",
 
     "searchServiceNameTidy": "[toLower(trim(parameters('searchServiceName')))]",
     "applicationInsightsNameTidy": "[toLower(trim(parameters('applicationInsightsName')))]",
     "applicationInsightsPricePlanTidy": "[toLower(trim(parameters('applicationInsightsPricePlan')))]",
-
     "authCertificateNameTidy": "[toLower(trim(parameters('authCertificateName')))]",
-
+    "omsWorkspaceNameTidy": "[toLower(trim(parameters('omsWorkspaceName')))]",
     "sitecoreTags": {
       "provider": "b51535c2-ab3e-4a68-95f8-e2e3c9a19299",
       "si": "si",
@@ -40,7 +36,7 @@
       "pools": "prc-pools",
       "tasks": "prc-tasks",
       "forms": "forms",
-      "exmmaster" : "exmmaster"
+      "exmmaster": "exmmaster"
     }
   },
   "parameters": {
@@ -53,7 +49,6 @@
       "minLength": 1,
       "defaultValue": "[resourceGroup().location]"
     },
-
     "sqlServerName": {
       "type": "string",
       "minLength": 1,
@@ -67,7 +62,6 @@
       "type": "securestring",
       "minLength": 8
     },
-
     "sqlServerVersion": {
       "type": "string",
       "minLength": 1,
@@ -84,9 +78,8 @@
       "defaultValue": "Standard"
     },
     "sqlDatabaseMaxSize": {
-      "type": "string",
-      "minLength": 1,
-      "defaultValue": "268435456000"
+      "type": "int",
+      "defaultValue": 268435456000
     },
     "sqlBasicDatabaseServiceObjectiveLevel": {
       "type": "string",
@@ -98,7 +91,6 @@
       "minLength": 1,
       "defaultValue": "S1"
     },
-
     "coreSqlDatabaseName": {
       "type": "string",
       "minLength": 1,
@@ -139,7 +131,7 @@
       "type": "bool",
       "defaultValue": true
     },
-    
+
     "searchServiceName": {
       "type": "string",
       "defaultValue": "[concat(parameters('deploymentId'), '-as')]"
@@ -182,13 +174,15 @@
     "applicationInsightsCurrentBillingFeatures": {
       "type": "string",
       "defaultValue": "Basic",
-      "allowedValues": [ "Basic", "Application Insights Enterprise" ]
+      "allowedValues": [
+        "Basic",
+        "Application Insights Enterprise"
+      ]
     },
     "applicationInsightsDataVolumeCap": {
       "type": "string",
       "defaultValue": "0.33"
     },
-
     "singleHostingPlanName": {
       "type": "string",
       "minLength": 1,
@@ -202,7 +196,6 @@
       "type": "int",
       "defaultValue": 1
     },
-
     "siWebAppName": {
       "type": "string",
       "minLength": 1,
@@ -225,6 +218,26 @@
     "authCertificatePassword": {
       "type": "securestring",
       "minLength": 1
+    },
+    "omsCapSizeGb": {
+      "defaultValue": 1,
+      "type": "int"
+    },
+    "omsWorkspaceMetricsRetentionDays": {
+      "defaultValue": 7,
+      "type": "int"
+    },
+    "omsWorkspaceSku": {
+      "defaultValue": "standalone",
+      "type": "string"
+    },
+    "omsWorkspaceName": {
+      "defaultValue": "[concat(parameters('deploymentId'), '-oms')]",
+      "type": "string"
+    },
+    "minTlsVersion": {
+      "defaultValue": "1.2",
+      "type": "string"
     }
   },
   "resources": [
@@ -305,7 +318,8 @@
       "properties": {
         "administratorLogin": "[parameters('sqlServerLogin')]",
         "administratorLoginPassword": "[parameters('sqlServerPassword')]",
-        "version": "[parameters('sqlServerVersion')]"
+        "version": "[parameters('sqlServerVersion')]",
+        "minimalTlsVersion": "[parameters('minTlsVersion')]"
       },
       "name": "[variables('sqlServerNameTidy')]",
       "location": "[parameters('location')]",
@@ -321,16 +335,20 @@
             "startIpAddress": "0.0.0.0"
           },
           "name": "AllowAllAzureIps",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ]
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ]
         },
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -339,15 +357,17 @@
               "dependsOn": [
                 "[variables('coreSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('coreSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').core]"
@@ -356,11 +376,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -369,15 +391,17 @@
               "dependsOn": [
                 "[variables('masterSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('masterSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').master]"
@@ -386,11 +410,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -399,15 +425,17 @@
               "dependsOn": [
                 "[variables('webSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('webSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').web]"
@@ -416,11 +444,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -429,15 +459,17 @@
               "dependsOn": [
                 "[variables('poolsSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('poolsSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').pools]"
@@ -446,11 +478,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -459,15 +493,17 @@
               "dependsOn": [
                 "[variables('tasksSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('tasksSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').tasks]"
@@ -476,11 +512,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -489,15 +527,17 @@
               "dependsOn": [
                 "[variables('formsSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('formsSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').forms]"
@@ -506,11 +546,13 @@
         {
           "type": "databases",
           "apiVersion": "[variables('dbApiVersion')]",
+          "sku": {
+            "name": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]",
+            "tier": "[parameters('sqlDatabaseEdition')]"
+          },
           "properties": {
-            "edition": "[parameters('sqlDatabaseEdition')]",
             "collation": "[parameters('sqlDatabaseCollation')]",
-            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]",
-            "requestedServiceObjectiveName": "[parameters('sqlBasicDatabaseServiceObjectiveLevel')]"
+            "maxSizeBytes": "[parameters('sqlDatabaseMaxSize')]"
           },
           "resources": [
             {
@@ -519,15 +561,17 @@
               "dependsOn": [
                 "[variables('exmMasterSqlDatabaseNameTidy')]"
               ],
-              "apiVersion": "2014-04-01",
+              "apiVersion": "[variables('dbApiVersion')]",
               "properties": {
-                "status": "Enabled"
+                "state": "Enabled"
               }
             }
           ],
           "name": "[variables('exmMasterSqlDatabaseNameTidy')]",
           "location": "[parameters('location')]",
-          "dependsOn": [ "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]" ],
+          "dependsOn": [
+            "[resourceId('Microsoft.Sql/servers', variables('sqlServerNameTidy'))]"
+          ],
           "tags": {
             "provider": "[variables('sitecoreTags').provider]",
             "logicalName": "[variables('sitecoreTags').exmmaster]"
@@ -553,6 +597,25 @@
       }
     },
     {
+      "apiVersion": "[variables('omsWorkspaceApiVersion')]",
+      "name": "[variables('omsWorkspaceNameTidy')]",
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "condition": "[parameters('useApplicationInsights')]",
+      "location": "[parameters('applicationInsightsLocation')]",
+      "properties": {
+        "sku": {
+          "name": "[parameters('omsWorkspaceSku')]"
+        },
+        "retention": "[parameters('omsWorkspaceMetricsRetentionDays')]",
+        "workspaceCapping": {
+          "dailyQuotaGb": "[parameters('omsCapSizeGb')]"
+        }
+      },
+      "tags": {
+        "provider": "[variables('sitecoreTags').provider]"
+      }
+    },
+    {
       "type": "Microsoft.Insights/Components",
       "condition": "[parameters('useApplicationInsights')]",
       "name": "[variables('applicationInsightsNameTidy')]",
@@ -560,11 +623,15 @@
       "location": "[parameters('applicationInsightsLocation')]",
       "properties": {
         "ApplicationId": "[variables('applicationInsightsNameTidy')]",
-        "Application_Type": "web"
+        "Application_Type": "web",
+        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('omsWorkspaceNameTidy'))]"
       },
       "tags": {
         "provider": "[variables('sitecoreTags').provider]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('omsWorkspaceNameTidy'))]"
+      ]
     },
     {
       "type": "Microsoft.Insights/Components/CurrentBillingFeatures",


### PR DESCRIPTION
1. Replaced Application Insights (classic) with workspace-based Application Insights. Set retention policy to 1GB of data for last 7 days (for Sitecore SKUs XS to L) and to 2GB (for SKUs XL to 3XL).
2. Set minimal TLS version to 1.2 for resources: Azure Service Bus, SQL Server, WebApp services, Redis Cache services.
3. Updated API versions used in ARM templates: ARM template from 2014-04-01-preview to 2019-04-01, Azure Service Bus from 2017-04-01 to 2022-01-01-preview, SQL Server from 2014-04-01-preview to 2022-05-01-preview, Redis Cache from 2016-04-01 to 2020-06-01, Application Insights from 2015-05-01 to 2020-02-02-preview.