### PR TITLE
Add SXP 10.4.0 to Compatibility Table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Choose the compatible templates for your Sitecore version:
 | Sitecore 10.0.0  | Sitecore 10.0.0, 10.0.1, 10.0.2 and 10.0.3                            |
 | Sitecore 10.1.0  | Sitecore 10.1.0                                                       |
 | Sitecore 10.1.1  | Sitecore 10.1.1, 10.1.2, 10.1.3                                       |
-| Sitecore 10.2.0  | Sitecore 10.2.0, 10.2.1, 10.3.0, 10.3.1                               |
+| Sitecore 10.2.0  | Sitecore 10.2.0, 10.2.1, 10.3.0, 10.3.1, 10.4.0                       |
 | WFFM 8.2.3       | Web Forms For Marketers 8.2 Update-3, Update-4 and Update-5           |
 | WFFM 9.0.0       | Web Forms For Marketers 9.0				           |
 | AD 1.3.0         | Active Directory 1.3                                                  |


### PR DESCRIPTION
Added SXP 10.4.0 to compatibility table.
SXP 10.2.0 templates apply also for new release SXP 10.4.